### PR TITLE
App Page Improvements

### DIFF
--- a/packages/tildagon-app-directory-site/src/pages/apps/[code].astro
+++ b/packages/tildagon-app-directory-site/src/pages/apps/[code].astro
@@ -36,6 +36,8 @@ export async function getStaticPaths() {
       <dt>Source Code Repository</dt>
       <dd><a href={data.manifest.metadata.url}>{data.manifest.metadata.url}</a></dd>
     </dl>
+    <h2>Description</h2>
+    <p>{data.manifest.metadata.description}</p>
     <h2>Installation</h2>
     <p>
       To install {data.manifest.app.name} on your badge, launch the App Store app

--- a/packages/tildagon-app-directory-site/src/pages/apps/[code].astro
+++ b/packages/tildagon-app-directory-site/src/pages/apps/[code].astro
@@ -33,6 +33,8 @@ export async function getStaticPaths() {
       <dd>{data.manifest.metadata.version}</dd>
       <dt>License</dt>
       <dd>{data.manifest.metadata.license}</dd>
+      <dt>Source Code Repository</dt>
+      <dd><a href={data.manifest.metadata.url}>{data.manifest.metadata.url}</a></dd>
     </dl>
     <h2>Installation</h2>
     <p>


### PR DESCRIPTION
This adds a link to the source code (as defined in the app manifest), as well as the description for the app. One less step to peeking inside someones app 🙂 

![Screenshot of the install page with description and source code link](https://github.com/emfcamp/badge-2024-app-store/assets/10981005/07924959-70f6-4c8e-9d81-3c22abc9cf05)
