### PR TITLE
Add workflow-immortality workflow

### DIFF
--- a/.github/workflows/workflow-immortality.yml
+++ b/.github/workflows/workflow-immortality.yml
@@ -1,0 +1,21 @@
+name: GitHub Workflow Immortality
+
+on:
+  schedule:
+    # run once a month on the first day of the month at 00:20 UTC
+    - cron: '20 0 1 * *'
+  workflow_dispatch: {}
+
+jobs:
+  keepalive:
+    name: GitHub Workflow Immortality
+
+    runs-on: ubuntu-latest
+    permissions: {}
+
+    steps:
+      - name: Keep cronjob based triggers of GitHub workflows alive
+        uses: PhrozenByte/gh-workflow-immortality@v1
+        with:
+          secret: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+          repos: ${{ github.repository }}


### PR DESCRIPTION
I have added the workflow yml file but someone with the appropriate access will need to setup a personal access token and add it to the repo secrets, the workflow expects this to be called `PERSONAL_ACCESS_TOKEN`.

Docs here: https://github.com/marketplace/actions/github-workflow-immortality#how-to-use

Fixes #7 