### PR TITLE
add Background as an app category

### DIFF
--- a/packages/tildagon-app-directory-api/src/models/TildagonAppManifest.ts
+++ b/packages/tildagon-app-directory-api/src/models/TildagonAppManifest.ts
@@ -6,6 +6,7 @@ const TildagonAppCategory = z.union([
   z.literal("Media"),
   z.literal("Apps"),
   z.literal("Games"),
+  z.literal("Background"),
 ]);
 
 export const TildagonAppManifestSchema = z.object({


### PR DESCRIPTION
need to add Background as a category to stop the background apps from being filtered out.