### PR TITLE
Increase timeout in appstore generation

### DIFF
--- a/packages/tildagon-app-directory-api/index.ts
+++ b/packages/tildagon-app-directory-api/index.ts
@@ -57,6 +57,7 @@ const server = Bun.serve({
         return new Response("Not found", { status: 404 });
     }
   },
+  idleTimeout: 120,
 });
 
 const pidFile = `${process.cwd()}/.server.pid`;


### PR DESCRIPTION
The appstore is silently failing to generate its indeces, because of an implicit 10 second timeout https://github.com/emfcamp/badge-2024-app-store/actions/runs/20988925112/job/60329361715#step:5:221.

I believe this is affecting us now because more apps are getting added.