### PR TITLE
Simplify dev environment

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,0 +1,16 @@
+FROM node
+
+ARG PROJECT
+WORKDIR /opt/${PROJECT}
+
+RUN apt-get update && apt-get install -y nginx vim
+
+# YOLO
+RUN curl -fsSL https://bun.com/install | bash
+
+COPY ./ /opt/${PROJECT}
+
+COPY docker-config/bashrc /root/.bashrc
+COPY ./docker-config/entrypoint.sh /usr/local/bin/entrypoint
+RUN chmod +x /usr/local/bin/entrypoint
+ENTRYPOINT ["/usr/local/bin/entrypoint"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,34 @@
+PROJECT = $(shell basename $(shell pwd))
+ID = emfcamp/${PROJECT}
+
+build:
+	podman build \
+		--file Containerfile \
+		--build-arg PROJECT=${PROJECT} \
+		--tag ${ID} .
+
+run:
+	podman run \
+		--name ${PROJECT} \
+		--hostname ${PROJECT} \
+		--volume $(shell pwd):/opt/${PROJECT} \
+		--interactive \
+		--tty \
+		--rm \
+		--publish 3000:3000 \
+		--publish 4321:4321 \
+		${ID} \
+		bash
+
+exec:
+	podman exec \
+		--interactive \
+		--tty \
+		${PROJECT} \
+		bash
+
+install:
+	bun install
+
+serve:
+	APP_STORE_MOCK=true bun --filter='*' run dev --host="0.0.0.0"

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 PROJECT = $(shell basename $(shell pwd))
 ID = emfcamp/${PROJECT}
+SHELL := /bin/bash
 
 build:
 	podman build \
@@ -32,12 +33,12 @@ install:
 	bun install
 
 serve-all:
-	. /root/.config/emf/tildagon && \
-	GITHUB_TOKEN=${GITHUB_TOKEN} bun --filter='*' run dev --host="0.0.0.0"
+	source /root/.config/emf/tildagon && \
+	bun --filter='*' run dev --host="0.0.0.0"
 
 serve-api:
-	. /root/.config/emf/tildagon && \
-	GITHUB_TOKEN=${GITHUB_TOKEN} bun --filter='tildagon-app-directory-api' run dev --host="0.0.0.0"
+	source /root/.config/emf/tildagon && \
+	bun --filter='tildagon-app-directory-api' run dev --host="0.0.0.0"
 
 mock-serve-all:
 	APP_STORE_MOCK=true bun --filter='*' run dev --host="0.0.0.0"

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ run:
 		--name ${PROJECT} \
 		--hostname ${PROJECT} \
 		--volume $(shell pwd):/opt/${PROJECT} \
+		--volume ${HOME}/.config:/root/.config \
 		--interactive \
 		--tty \
 		--rm \
@@ -30,5 +31,16 @@ exec:
 install:
 	bun install
 
-serve:
+serve-all:
+	. /root/.config/emf/tildagon && \
+	GITHUB_TOKEN=${GITHUB_TOKEN} bun --filter='*' run dev --host="0.0.0.0"
+
+serve-api:
+	. /root/.config/emf/tildagon && \
+	GITHUB_TOKEN=${GITHUB_TOKEN} bun --filter='tildagon-app-directory-api' run dev --host="0.0.0.0"
+
+mock-serve-all:
 	APP_STORE_MOCK=true bun --filter='*' run dev --host="0.0.0.0"
+
+mock-serve-api:
+	APP_STORE_MOCK=true bun --filter='tildagon-app-directory-api' run dev --host="0.0.0.0"

--- a/README.md
+++ b/README.md
@@ -62,6 +62,28 @@ production app store on 2025-10-07.
 export APP_STORE_MOCK=true
 ```
 
+#### Running from a container
+
+There's a `Containerfile` and some `make` targets to make building all this slightly easier:
+
+Presuming you have [Podman](https://podman.io/) installed,
+
+```
+make build
+make run
+```
+
+and then from the container:
+
+```
+make install  # you only need do this once
+make serve
+```
+
+And you should have the [API](http://localhost:3000/v1/apps) and [frontend](http://localhost:4321/) working
+
+> This uses `APP_STORE_MOCK=true` to give you fake Github data, sweeten to taste if you need live data
+
 ##### Implementing a Registry Source
 
 `RegistrySource` is the name for a common interface we implement to let the app

--- a/README.md
+++ b/README.md
@@ -77,12 +77,26 @@ and then from the container:
 
 ```
 make install  # you only need do this once
-make serve
 ```
 
-And you should have the [API](http://localhost:3000/v1/apps) and [frontend](http://localhost:4321/) working
+and then try one of these:
 
-> This uses `APP_STORE_MOCK=true` to give you fake Github data, sweeten to taste if you need live data
+```
+make serve-api
+make serve-all
+make mock-serve-api
+make mock-serve-all
+```
+
+##### Credentials
+
+The first two targets there require an API token, as described above. They expect to find an `env` file at `${HOME}/.config/emf/tildagon` (`${HOME}/.config/` gets mounted into the container at `/root/.config`) with an entry like
+
+```
+export GITHUB_TOKEN=ghp_token_here
+```
+
+Depending on which targets you ran, you should have the [API](http://localhost:3000/v1/apps) and [frontend](http://localhost:4321/) working.
 
 ##### Implementing a Registry Source
 

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "badge-2024-app-store",
@@ -105,7 +106,7 @@
 
     "@emmetio/css-abbreviation": ["@emmetio/css-abbreviation@2.1.8", "", { "dependencies": { "@emmetio/scanner": "^1.0.4" } }, "sha512-s9yjhJ6saOO/uk1V74eifykk2CBYi01STTK3WlXWGOepyKa23ymJ053+DNQjpFcy1ingpaO7AxCcwLvHFY9tuw=="],
 
-    "@emmetio/css-parser": ["@emmetio/css-parser@github:ramya-rao-a/css-parser#370c480", { "dependencies": { "@emmetio/stream-reader": "^2.2.0", "@emmetio/stream-reader-utils": "^0.1.0" } }, "ramya-rao-a-css-parser-370c480"],
+    "@emmetio/css-parser": ["@emmetio/css-parser@github:ramya-rao-a/css-parser#370c480", { "dependencies": { "@emmetio/stream-reader": "^2.2.0", "@emmetio/stream-reader-utils": "^0.1.0" } }, "ramya-rao-a-css-parser-370c480", "sha512-dYkDEiBYU6kAT6FMOUEZM5QsIOvOJ4zVC5IYTRDizfhEuAptmf+tXSaGmJSRy4HEgqITT9Af7FZxbskdg6E2xg=="],
 
     "@emmetio/html-matcher": ["@emmetio/html-matcher@1.3.0", "", { "dependencies": { "@emmetio/scanner": "^1.0.0" } }, "sha512-NTbsvppE5eVyBMuyGfVu2CRrLvo7J4YHb6t9sBFLyY03WYhXET37qA4zOYUjBWFCRHO7pS1B9khERtY0f5JXPQ=="],
 

--- a/docker-config/bashrc
+++ b/docker-config/bashrc
@@ -1,0 +1,5 @@
+complete -W "\`grep -oE '^[a-zA-Z0-9_.-]+:([^=]|$)' Makefile | sed 's/[^a-zA-Z0-9_.-]*$//'\`" make
+
+export PATH=./node_modules/.bin/:~/.bun/bin/:${PATH}
+
+export PS1="[\w] # "

--- a/docker-config/entrypoint.sh
+++ b/docker-config/entrypoint.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+function __show_help() {
+  echo "Container entrypoint commands:"
+  echo "  help - show this help"
+  echo ""
+  echo "Any other command will be executed within the container."
+}
+
+nginx
+
+case ${1} in
+help)
+  __show_help
+  ;;
+
+*)
+  exec "$@"
+  ;;
+esac

--- a/packages/tildagon-app-directory-api/src/registries/CachedRegistryManager.ts
+++ b/packages/tildagon-app-directory-api/src/registries/CachedRegistryManager.ts
@@ -14,76 +14,90 @@ import { CodebergRegistry } from "./sources/codeberg";
 const AppCache = new Map<string, TildagonAppRelease>();
 const ErrorCache = new Map<string, RegistrySourceFailure>();
 
+if (process.env.APP_STORE_MOCK) {
+  console.log("Mocking the app store data");
+} else {
+  console.log("Using real data");
+}
+
 const SOURCES = process.env.APP_STORE_MOCK
   ? [DummyRegistry]
   : [GitHubRegistry, CodebergRegistry];
 
+let bugfix_permacache_flag = false;
+
 export const CachedRegistryManager = {
   async listApps() {
-    await Promise.all(
-      SOURCES.map(async (source) => {
-        return await Promise.all(
-          (await source.list())
+    if (!bugfix_permacache_flag) {
+      await Promise.all(
+        SOURCES.map(async (source) => {
+          return await Promise.all(
+            (await source.list())
 
-            .map((result) => {
-              if (result.type === "failure") {
-                ErrorCache.set(
-                  TildagonAppReleaseIdentifier.toAppCode(result.failure.id),
-                  result.failure,
-                );
-              }
-              return result;
-            })
-            .filter((result) => result.type === "success")
-            .map(async (result) => {
-              if (result.type === "success") {
-                const code = TildagonAppReleaseIdentifier.toAppCode(
-                  result.value.id,
-                );
-
-                const disallowReason = disallowedApps.find((disallowSpec) => {
-                  return Object.entries(disallowSpec).every(([key, value]) => {
-                    return result.value.id.hasOwnProperty(key)
-                      ? result.value.id[key as keyof typeof result.value.id] ===
-                          value
-                      : true;
-                  });
-                });
-
-                if (disallowReason) {
-                  ErrorCache.set(code, {
-                    id: result.value.id,
-                    reason: `Ban: ${JSON.stringify(disallowReason, null, 2)}`,
-                  });
-                  return "done";
+              .map((result) => {
+                if (result.type === "failure") {
+                  ErrorCache.set(
+                    TildagonAppReleaseIdentifier.toAppCode(result.failure.id),
+                    result.failure,
+                  );
                 }
+                return result;
+              })
+              .filter((result) => result.type === "success")
+              .map(async (result) => {
+                if (result.type === "success") {
+                  const code = TildagonAppReleaseIdentifier.toAppCode(
+                    result.value.id,
+                  );
 
-                // Early exit if we already have this release
-                if (AppCache.has(code)) {
-                  const cachedApp = AppCache.get(code);
-                  if (!Bun.deepEquals(cachedApp?.id, result.value.id)) {
+                  const disallowReason = disallowedApps.find((disallowSpec) => {
+                    return Object.entries(disallowSpec).every(
+                      ([key, value]) => {
+                        return result.value.id.hasOwnProperty(key)
+                          ? result.value.id[
+                              key as keyof typeof result.value.id
+                            ] === value
+                          : true;
+                      },
+                    );
+                  });
+
+                  if (disallowReason) {
                     ErrorCache.set(code, {
                       id: result.value.id,
-                      reason: `Hash collision with ${code} - ${cachedApp?.manifest.app.name}`,
+                      reason: `Ban: ${JSON.stringify(disallowReason, null, 2)}`,
                     });
+                    return "done";
                   }
-                  return "done";
-                }
 
-                // Here's where we would emit a "we found a new app" event
+                  // Early exit if we already have this release
+                  if (AppCache.has(code)) {
+                    const cachedApp = AppCache.get(code);
+                    if (!Bun.deepEquals(cachedApp?.id, result.value.id)) {
+                      ErrorCache.set(code, {
+                        id: result.value.id,
+                        reason: `Hash collision with ${code} - ${cachedApp?.manifest.app.name}`,
+                      });
+                    }
+                    return "done";
+                  }
 
-                const appResult = await source.get(code, result.value);
-                if (Result.isNotOk(appResult)) {
-                  ErrorCache.set(code, appResult.failure);
-                } else if (Result.isOk(appResult)) {
-                  AppCache.set(code, appResult.value);
+                  // Here's where we would emit a "we found a new app" event
+
+                  const appResult = await source.get(code, result.value);
+                  if (Result.isNotOk(appResult)) {
+                    ErrorCache.set(code, appResult.failure);
+                  } else if (Result.isOk(appResult)) {
+                    AppCache.set(code, appResult.value);
+                  }
                 }
-              }
-              return "done";
-            }),
-        );
-      }),
-    );
+                return "done";
+              }),
+          );
+        }),
+      );
+    }
+    bugfix_permacache_flag = true;
 
     return Array.from(AppCache.values()).toSorted((a, b) =>
       a.manifest.app.name

--- a/packages/tildagon-app-directory-api/src/registries/CachedRegistryManager.ts
+++ b/packages/tildagon-app-directory-api/src/registries/CachedRegistryManager.ts
@@ -33,17 +33,16 @@ export const CachedRegistryManager = {
         SOURCES.map(async (source) => {
           return await Promise.all(
             (await source.list())
-
-              .map((result) => {
+              .filter((result) => {
                 if (result.type === "failure") {
                   ErrorCache.set(
                     TildagonAppReleaseIdentifier.toAppCode(result.failure.id),
                     result.failure,
                   );
+                  return false;
                 }
-                return result;
+                return true;
               })
-              .filter((result) => result.type === "success")
               .map(async (result) => {
                 if (result.type === "success") {
                   const code = TildagonAppReleaseIdentifier.toAppCode(

--- a/packages/tildagon-app-directory-api/src/registries/sources/codeberg.ts
+++ b/packages/tildagon-app-directory-api/src/registries/sources/codeberg.ts
@@ -20,6 +20,7 @@ async function getTildagonApps(): RegistrySourceListResult<MetadataFromListing> 
   const results = await api.repos.repoSearch({
     q: "tildagon-app",
     topic: true,
+    archived: false,
   });
 
   return await Promise.all(

--- a/packages/tildagon-app-directory-api/src/registries/sources/github.ts
+++ b/packages/tildagon-app-directory-api/src/registries/sources/github.ts
@@ -106,6 +106,9 @@ async function getTildagonApps(): Promise<
       return null;
     },
   )) {
+    console.log(
+      `Reading GitHub Search Result Page ${page.search.pageInfo.cursor} with ${page.search.nodes.length} matching repositories`,
+    );
     const pageApps = await Promise.all(
       page.search.nodes
         .map(

--- a/packages/tildagon-app-directory-api/src/registries/sources/github.ts
+++ b/packages/tildagon-app-directory-api/src/registries/sources/github.ts
@@ -96,7 +96,8 @@ async function getTildagonApps(): Promise<
 
   for await (const page of pageThroughResource<GraphQlQueryResponseData>(
     async (after?: string) => {
-      return await octokit.graphql(LIST_QUERY, { parameters: { after } });
+      console.log(`Making GitHub List Page Query`);
+      return await octokit.graphql(LIST_QUERY, { after });
     },
     (result: any): string | null => {
       if (result.search.pageInfo.hasNextPage) {
@@ -193,6 +194,7 @@ async function getTildagonApp(
   found: Omit<TildagonAppRelease, "manifest">,
 ): Promise<Result<TildagonAppRelease, RegistrySourceFailure>> {
   try {
+    console.log(`Making GitHub Single App Query ${code}`);
     const response = await octokit.rest.repos.getContent({
       ref: found.id.releaseHash,
       owner: found.id.owner,

--- a/packages/tildagon-app-directory-api/src/registries/sources/github.ts
+++ b/packages/tildagon-app-directory-api/src/registries/sources/github.ts
@@ -106,6 +106,7 @@ async function getTildagonApps(): Promise<
       return null;
     },
   )) {
+    console.log(page);
     console.log(
       `Reading GitHub Search Result Page ${page.search.pageInfo.cursor} with ${page.search.nodes.length} matching repositories`,
     );

--- a/packages/tildagon-app-directory-api/src/registries/sources/github.ts
+++ b/packages/tildagon-app-directory-api/src/registries/sources/github.ts
@@ -38,7 +38,7 @@ export type GitHubRegistryListQueryResult = z.infer<
 
 const LIST_QUERY = `
  query ListTildagonAppsQuery($after: String){
-  search(query: "topic:tildagon-app fork:true", type: REPOSITORY, first: 100, after: $after) {
+  search(query: "topic:tildagon-app fork:true archived:false", type: REPOSITORY, first: 100, after: $after) {
     repositoryCount
     pageInfo {
       endCursor,

--- a/packages/tildagon-app-directory-site/src/pages/apps/[code].astro
+++ b/packages/tildagon-app-directory-site/src/pages/apps/[code].astro
@@ -52,3 +52,9 @@ export async function getStaticPaths() {
     <InstallationInstructions code={data.code} />
   </main>
 </Layout>
+
+<style>
+  a {
+    color: #528329;
+  }
+</style>

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -2,7 +2,7 @@
 
 bun --filter='tildagon-app' run build
 
-bun --filter='tildagon-app-directory-api' run dev &
+bun --filter='tildagon-app-directory-api' --elide-lines=0 run dev &
 
 sleep 5
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+export APP_STORE_MOCK=true
+
 bun --filter='tildagon-app' run build
 
 bun --filter='tildagon-app-directory-api' run dev &

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -29,6 +29,6 @@ BUILD_STATUS=$?
 # kill $DIRECTORY_PID
 # rm .server.pid
 
-kill "$(pidof bun)"
+kill $(pidof bun)
 
 exit "$BUILD_STATUS"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -2,7 +2,7 @@
 
 bun --filter='tildagon-app' run build
 
-bun --filter='tildagon-app-directory-api' --elide-lines=0 run dev &
+bun --filter='tildagon-app-directory-api' run dev &
 
 sleep 5
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 
-export APP_STORE_MOCK=true
-
 bun --filter='tildagon-app' run build
 
 bun --filter='tildagon-app-directory-api' run dev &
@@ -11,7 +9,12 @@ sleep 5
 # DIRECTORY_PID=$(cat .server.pid)
 # echo $DIRECTORY_PID
 
-curl http://localhost:3000/v1/apps
+curl -s http://localhost:3000/v1/apps
+
+exit_status=$?
+if [ $exit_status != 0 ]; then
+  exit $exit_status
+fi
 
 bun --filter='tildagon-app-directory-site' run build
 BUILD_STATUS=$?


### PR DESCRIPTION
Add a Containerfile and Makefile to simplify creation and isolation of a dev environment

I've now refined it to give some more granular `make` targets

There's also a tiny tweak to the `build` script due to multiple `bun` processes