### PR TITLE
Apply correct styling to the links on individual app pages

### DIFF
--- a/packages/tildagon-app-directory-site/src/pages/apps/[code].astro
+++ b/packages/tildagon-app-directory-site/src/pages/apps/[code].astro
@@ -52,3 +52,9 @@ export async function getStaticPaths() {
     <InstallationInstructions code={data.code} />
   </main>
 </Layout>
+
+<style>
+  a {
+    color: #528329;
+  }
+</style>


### PR DESCRIPTION
The link on individual app pages were defaulting to black and were hard to read. This colours them green

I couldn't find the colours centrally defined anywhere so I just yoinked the hex colour from somewhere else