### PR TITLE
feat: hardware support

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,6 +23,8 @@ jobs:
         uses: jdx/mise-action@v4
       - name: Install dependencies
         run: npm install
+      - name: Run tests
+        run: npm run test
       - name: Run directory
         run: mise run build-website
         env:

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,8 +40,6 @@
     },
     "node_modules/@astrojs/check": {
       "version": "0.9.9",
-      "resolved": "https://registry.npmjs.org/@astrojs/check/-/check-0.9.9.tgz",
-      "integrity": "sha512-A5UW8uIuErLWEoRQvzgXpO1gTjUFtK8r7nU2Z7GewAMxUb7bPvpk11qaKKgxqXlHJWlAvaaxy+Xg28A6bmQ1Tg==",
       "license": "MIT",
       "dependencies": {
         "@astrojs/language-server": "^2.16.7",
@@ -129,18 +127,21 @@
       "license": "MIT"
     },
     "node_modules/@astrojs/internal-helpers": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/@astrojs/internal-helpers/-/internal-helpers-0.9.1.tgz",
-      "integrity": "sha512-1pWuARqYom/TzuU3+0ZugsTrKlUydWKuULmDqSMTuonY+9IRDUEGKX/8PXQ1nBxRq3w85uGtd9q9SXfqEldMIQ==",
+      "version": "0.10.0",
       "license": "MIT",
       "dependencies": {
-        "picomatch": "^4.0.4"
+        "@types/hast": "^3.0.4",
+        "@types/mdast": "^4.0.4",
+        "js-yaml": "^4.1.1",
+        "picomatch": "^4.0.4",
+        "retext-smartypants": "^6.2.0",
+        "shiki": "^4.0.2",
+        "smol-toml": "^1.6.0",
+        "unified": "^11.0.5"
       }
     },
     "node_modules/@astrojs/language-server": {
       "version": "2.16.9",
-      "resolved": "https://registry.npmjs.org/@astrojs/language-server/-/language-server-2.16.9.tgz",
-      "integrity": "sha512-L9kddTg+ZSO3X0Pwfx0ZPO+Z+eSSq0/39jXRyIkHzcBICzusdn2T464R4P6K0WcDZ6pMkLlFpuGS73u1pOnMSw==",
       "license": "MIT",
       "dependencies": {
         "@astrojs/compiler": "^2.13.1",
@@ -180,22 +181,17 @@
     },
     "node_modules/@astrojs/language-server/node_modules/@astrojs/compiler": {
       "version": "2.13.1",
-      "resolved": "https://registry.npmjs.org/@astrojs/compiler/-/compiler-2.13.1.tgz",
-      "integrity": "sha512-f3FN83d2G/v32ipNClRKgYv30onQlMZX1vCeZMjPsMMPl1mDpmbl0+N5BYo4S/ofzqJyS5hvwacEo0CCVDn/Qg==",
       "license": "MIT"
     },
     "node_modules/@astrojs/markdown-remark": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/@astrojs/markdown-remark/-/markdown-remark-7.1.2.tgz",
-      "integrity": "sha512-caXZ4Dc2St2dW8luEg22GlP0gupLdztCTQE4EzZOxW1pqWXz9mbeJEuHUkgDYcKWW8tjIHkydYDhWLVoxJ327Q==",
+      "version": "7.2.0",
       "license": "MIT",
       "dependencies": {
-        "@astrojs/internal-helpers": "0.9.1",
+        "@astrojs/internal-helpers": "0.10.0",
         "@astrojs/prism": "4.0.2",
         "github-slugger": "^2.0.0",
         "hast-util-from-html": "^2.0.3",
         "hast-util-to-text": "^4.0.2",
-        "js-yaml": "^4.1.1",
         "mdast-util-definitions": "^6.0.0",
         "rehype-raw": "^7.0.0",
         "rehype-stringify": "^10.0.1",
@@ -203,9 +199,6 @@
         "remark-parse": "^11.0.0",
         "remark-rehype": "^11.1.2",
         "remark-smartypants": "^3.0.2",
-        "retext-smartypants": "^6.2.0",
-        "shiki": "^4.0.0",
-        "smol-toml": "^1.6.0",
         "unified": "^11.0.5",
         "unist-util-remove-position": "^5.0.0",
         "unist-util-visit": "^5.1.0",
@@ -215,8 +208,6 @@
     },
     "node_modules/@astrojs/prism": {
       "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@astrojs/prism/-/prism-4.0.2.tgz",
-      "integrity": "sha512-KTivpmnz6lDsC6o9H4+DNm2SrE/GHzw8cNAvEJwAvUT+eoaEnn/4NtbDNfRRaxaJHdp15gf+tfHAWiXR4wB3BA==",
       "license": "MIT",
       "dependencies": {
         "prismjs": "^1.30.0"
@@ -227,8 +218,6 @@
     },
     "node_modules/@astrojs/telemetry": {
       "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/@astrojs/telemetry/-/telemetry-3.3.2.tgz",
-      "integrity": "sha512-j8DNruA8ors99Al39RYZPJK4DC1bKkoNm93mAMuBhY9TCNC4R8n1q7ovFnJ5qhGh5Lsh7pa1gpQVpYpsJPeTHQ==",
       "license": "MIT",
       "dependencies": {
         "ci-info": "^4.4.0",
@@ -243,8 +232,6 @@
     },
     "node_modules/@astrojs/yaml2ts": {
       "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/@astrojs/yaml2ts/-/yaml2ts-0.2.4.tgz",
-      "integrity": "sha512-8oddpOae35pJsXPQXhTkM0ypfKPskVsh2bCxRtbf7e+/Epw2nReakFYpLKjZMEr75CsoF203PMnCocpfz0s69A==",
       "license": "MIT",
       "dependencies": {
         "yaml": "^2.8.3"
@@ -252,8 +239,6 @@
     },
     "node_modules/@astrojs/yaml2ts/node_modules/yaml": {
       "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
-      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"
@@ -266,10 +251,10 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.27.1",
+      "version": "7.29.7",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -277,37 +262,365 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.7",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.7",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/core/node_modules/semver": {
+      "version": "6.3.1",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.7",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.29.7",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/lru-cache": {
+      "version": "5.1.1",
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
+      "version": "6.3.1",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/yallist": {
+      "version": "3.1.1",
+      "license": "ISC"
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.29.7",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.29.7",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.29.7",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.29.7",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "version": "7.29.7",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "version": "7.29.7",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/parser": {
-      "version": "7.29.3",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
-      "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.29.7",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.7",
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.29.0"
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.7",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.7"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-async-generators": {
+      "version": "7.8.4",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-bigint": {
+      "version": "7.8.3",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-class-properties": {
+      "version": "7.12.13",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.12.13"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-class-static-block": {
+      "version": "7.14.5",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-import-attributes": {
+      "version": "7.29.7",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-import-meta": {
+      "version": "7.10.4",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-json-strings": {
+      "version": "7.8.3",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-jsx": {
+      "version": "7.29.7",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-logical-assignment-operators": {
+      "version": "7.10.4",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-nullish-coalescing-operator": {
+      "version": "7.8.3",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-numeric-separator": {
+      "version": "7.10.4",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-object-rest-spread": {
+      "version": "7.8.3",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-optional-catch-binding": {
+      "version": "7.8.3",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-optional-chaining": {
+      "version": "7.8.3",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-private-property-in-object": {
+      "version": "7.14.5",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-top-level-await": {
+      "version": "7.14.5",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-typescript": {
+      "version": "7.29.7",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/runtime": {
@@ -317,23 +630,51 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/types": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+    "node_modules/@babel/template": {
+      "version": "7.29.7",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.7",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.7",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "0.2.3",
+      "license": "MIT"
+    },
     "node_modules/@capsizecss/unpack": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@capsizecss/unpack/-/unpack-4.0.0.tgz",
-      "integrity": "sha512-VERIM64vtTP1C4mxQ5thVT9fK0apjPFobqybMtA1UdUujWka24ERHbRHFGmpbbhp73MhV+KSsHQH9C6uOTdEQA==",
       "license": "MIT",
       "dependencies": {
         "fontkitten": "^1.0.0"
@@ -344,8 +685,6 @@
     },
     "node_modules/@clack/core": {
       "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@clack/core/-/core-1.3.1.tgz",
-      "integrity": "sha512-fT1qHVGAag4IEkrupZ6lRRbNCs1vS9P01KB/sG8zKgvUztbYtFBtQpjSITNwooDZ83tpsPzP0mRNs1/KVszCRA==",
       "license": "MIT",
       "dependencies": {
         "fast-wrap-ansi": "^0.2.0",
@@ -357,8 +696,6 @@
     },
     "node_modules/@clack/prompts": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@clack/prompts/-/prompts-1.4.0.tgz",
-      "integrity": "sha512-S0My7XPGIgpRWMDG8uRqalbgT+a6FmCUdOW+HaIOVVpUPHOb7RrpvjTjiODadKp06fsrVDJZlIzc6yCTp4AnxA==",
       "license": "MIT",
       "dependencies": {
         "@clack/core": "1.3.1",
@@ -372,8 +709,6 @@
     },
     "node_modules/@emmetio/abbreviation": {
       "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/@emmetio/abbreviation/-/abbreviation-2.3.3.tgz",
-      "integrity": "sha512-mgv58UrU3rh4YgbE/TzgLQwJ3pFsHHhCLqY20aJq+9comytTXUDNGG/SMtSeMJdkpxgXSXunBGLD8Boka3JyVA==",
       "license": "MIT",
       "dependencies": {
         "@emmetio/scanner": "^1.0.4"
@@ -381,8 +716,6 @@
     },
     "node_modules/@emmetio/css-abbreviation": {
       "version": "2.1.8",
-      "resolved": "https://registry.npmjs.org/@emmetio/css-abbreviation/-/css-abbreviation-2.1.8.tgz",
-      "integrity": "sha512-s9yjhJ6saOO/uk1V74eifykk2CBYi01STTK3WlXWGOepyKa23ymJ053+DNQjpFcy1ingpaO7AxCcwLvHFY9tuw==",
       "license": "MIT",
       "dependencies": {
         "@emmetio/scanner": "^1.0.4"
@@ -390,8 +723,6 @@
     },
     "node_modules/@emmetio/css-parser": {
       "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@emmetio/css-parser/-/css-parser-0.4.1.tgz",
-      "integrity": "sha512-2bC6m0MV/voF4CTZiAbG5MWKbq5EBmDPKu9Sb7s7nVcEzNQlrZP6mFFFlIaISM8X6514H9shWMme1fCm8cWAfQ==",
       "license": "MIT",
       "dependencies": {
         "@emmetio/stream-reader": "^2.2.0",
@@ -400,8 +731,6 @@
     },
     "node_modules/@emmetio/html-matcher": {
       "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@emmetio/html-matcher/-/html-matcher-1.3.0.tgz",
-      "integrity": "sha512-NTbsvppE5eVyBMuyGfVu2CRrLvo7J4YHb6t9sBFLyY03WYhXET37qA4zOYUjBWFCRHO7pS1B9khERtY0f5JXPQ==",
       "license": "ISC",
       "dependencies": {
         "@emmetio/scanner": "^1.0.0"
@@ -409,8 +738,6 @@
     },
     "node_modules/@emmetio/scanner": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@emmetio/scanner/-/scanner-1.0.4.tgz",
-      "integrity": "sha512-IqRuJtQff7YHHBk4G8YZ45uB9BaAGcwQeVzgj/zj8/UdOhtQpEIupUhSk8dys6spFIWVZVeK20CzGEnqR5SbqA==",
       "license": "MIT"
     },
     "node_modules/@emmetio/stream-reader": {
@@ -423,8 +750,6 @@
     },
     "node_modules/@emotion/is-prop-valid": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.4.0.tgz",
-      "integrity": "sha512-QgD4fyscGcbbKwJmqNvUMSE02OsHUa+lAWKdEUIJKgqe5IwRSKd7+KhibEWdaKwgjLj0DRSHA9biAIqGBk05lw==",
       "license": "MIT",
       "dependencies": {
         "@emotion/memoize": "^0.9.0"
@@ -432,270 +757,10 @@
     },
     "node_modules/@emotion/memoize": {
       "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.9.0.tgz",
-      "integrity": "sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==",
       "license": "MIT"
-    },
-    "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
-      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
-      "cpu": [
-        "ppc64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "aix"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/android-arm": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
-      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/android-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
-      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/android-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
-      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
-      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/darwin-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
-      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
-      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
-      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-arm": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
-      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
-      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-ia32": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
-      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
-      "cpu": [
-        "ia32"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-loong64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
-      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
-      "cpu": [
-        "loong64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
-      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
-      "cpu": [
-        "mips64el"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
-      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
-      "cpu": [
-        "ppc64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
-      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
-      "cpu": [
-        "riscv64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-s390x": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
-      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
-      "cpu": [
-        "s390x"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
     },
     "node_modules/@esbuild/linux-x64": {
       "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
-      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
       "cpu": [
         "x64"
       ],
@@ -703,150 +768,6 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
-      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
-      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
-      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
-      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
-      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openharmony"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/sunos-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
-      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
-      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-ia32": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
-      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
-      "cpu": [
-        "ia32"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
-      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
       ],
       "engines": {
         "node": ">=18"
@@ -858,8 +779,6 @@
     },
     "node_modules/@faker-js/faker": {
       "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-7.6.0.tgz",
-      "integrity": "sha512-XK6BTq1NDMo9Xqw/YkYyGjSsg44fbNwYRx7QK2CuoQgyy+f1rrTDHoExVM5PsyXCtfl2vs2vVJ0MN0yN6LppRw==",
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0",
@@ -875,8 +794,6 @@
     },
     "node_modules/@humanwhocodes/momoa": {
       "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/momoa/-/momoa-2.0.4.tgz",
-      "integrity": "sha512-RE815I4arJFtt+FVeU1Tgp9/Xvecacji8w/V6XtXsWWH/wz/eNkNbhb+ny/+PlVZjV0rxQpRSQKNKE3lcktHEA==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=10.10.0"
@@ -884,28 +801,26 @@
     },
     "node_modules/@iconify-json/openmoji": {
       "version": "1.2.27",
-      "resolved": "https://registry.npmjs.org/@iconify-json/openmoji/-/openmoji-1.2.27.tgz",
-      "integrity": "sha512-pIH1ofyNMYOD1vysHYtRzhAMMftcdmw+kCdzr/GDxIIa8jU4XrK3LzZcMs+kHXWzNaZL13VZkJ7H+a07BPWiiQ==",
       "license": "CC-BY-SA-4.0",
       "dependencies": {
         "@iconify/types": "*"
       }
     },
     "node_modules/@iconify/tools": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@iconify/tools/-/tools-4.2.0.tgz",
-      "integrity": "sha512-WRxPva/ipxYkqZd1+CkEAQmd86dQmrwH0vwK89gmp2Kh2WyyVw57XbPng0NehP3x4V1LzLsXUneP1uMfTMZmUA==",
+      "version": "4.1.2",
       "license": "MIT",
       "dependencies": {
         "@iconify/types": "^2.0.0",
         "@iconify/utils": "^2.3.0",
-        "cheerio": "^1.1.2",
+        "@types/tar": "^6.1.13",
+        "axios": "^1.8.3",
+        "cheerio": "1.0.0",
         "domhandler": "^5.0.3",
         "extract-zip": "^2.0.1",
-        "local-pkg": "^1.1.2",
-        "pathe": "^2.0.3",
+        "local-pkg": "^0.5.1",
+        "pathe": "^1.1.2",
         "svgo": "^3.3.2",
-        "tar": "^7.5.2"
+        "tar": "^6.2.1"
       }
     },
     "node_modules/@iconify/types": {
@@ -925,6 +840,38 @@
         "local-pkg": "^1.0.0",
         "mlly": "^1.7.4"
       }
+    },
+    "node_modules/@iconify/utils/node_modules/local-pkg": {
+      "version": "1.1.1",
+      "license": "MIT",
+      "dependencies": {
+        "mlly": "^1.7.4",
+        "pkg-types": "^2.0.1",
+        "quansync": "^0.2.8"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@iconify/utils/node_modules/local-pkg/node_modules/pkg-types": {
+      "version": "2.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "confbox": "^0.2.1",
+        "exsolve": "^1.0.1",
+        "pathe": "^2.0.3"
+      }
+    },
+    "node_modules/@iconify/utils/node_modules/local-pkg/node_modules/pkg-types/node_modules/confbox": {
+      "version": "0.2.2",
+      "license": "MIT"
+    },
+    "node_modules/@iconify/utils/node_modules/local-pkg/node_modules/pkg-types/node_modules/pathe": {
+      "version": "2.0.3",
+      "license": "MIT"
     },
     "node_modules/@img/colour": {
       "version": "1.0.0",
@@ -1002,32 +949,479 @@
         "@img/sharp-libvips-linuxmusl-x64": "1.2.3"
       }
     },
-    "node_modules/@isaacs/fs-minipass": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
-      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
       "license": "ISC",
       "dependencies": {
-        "minipass": "^7.0.4"
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=12"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "license": "MIT"
+    },
+    "node_modules/@isaacs/cliui/node_modules/string-width": {
+      "version": "5.1.2",
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config": {
+      "version": "1.1.0",
+      "license": "ISC",
+      "dependencies": {
+        "camelcase": "^5.3.1",
+        "find-up": "^4.1.0",
+        "get-package-type": "^0.1.0",
+        "js-yaml": "^3.13.1",
+        "resolve-from": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/argparse": {
+      "version": "1.0.10",
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
+      "version": "3.14.2",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.6",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jest/console": {
+      "version": "30.4.1",
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.4.1",
+        "@types/node": "*",
+        "chalk": "^4.1.2",
+        "jest-message-util": "30.4.1",
+        "jest-util": "30.4.1",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/core": {
+      "version": "30.4.2",
+      "license": "MIT",
+      "dependencies": {
+        "@jest/console": "30.4.1",
+        "@jest/pattern": "30.4.0",
+        "@jest/reporters": "30.4.1",
+        "@jest/test-result": "30.4.1",
+        "@jest/transform": "30.4.1",
+        "@jest/types": "30.4.1",
+        "@types/node": "*",
+        "ansi-escapes": "^4.3.2",
+        "chalk": "^4.1.2",
+        "ci-info": "^4.2.0",
+        "exit-x": "^0.2.2",
+        "fast-json-stable-stringify": "^2.1.0",
+        "graceful-fs": "^4.2.11",
+        "jest-changed-files": "30.4.1",
+        "jest-config": "30.4.2",
+        "jest-haste-map": "30.4.1",
+        "jest-message-util": "30.4.1",
+        "jest-regex-util": "30.4.0",
+        "jest-resolve": "30.4.1",
+        "jest-resolve-dependencies": "30.4.2",
+        "jest-runner": "30.4.2",
+        "jest-runtime": "30.4.2",
+        "jest-snapshot": "30.4.1",
+        "jest-util": "30.4.1",
+        "jest-validate": "30.4.1",
+        "jest-watcher": "30.4.1",
+        "pretty-format": "30.4.1",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@jest/diff-sequences": {
+      "version": "30.4.0",
+      "license": "MIT",
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/environment": {
+      "version": "30.4.1",
+      "license": "MIT",
+      "dependencies": {
+        "@jest/fake-timers": "30.4.1",
+        "@jest/types": "30.4.1",
+        "@types/node": "*",
+        "jest-mock": "30.4.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/expect": {
+      "version": "30.4.1",
+      "license": "MIT",
+      "dependencies": {
+        "expect": "30.4.1",
+        "jest-snapshot": "30.4.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/expect-utils": {
+      "version": "30.4.1",
+      "license": "MIT",
+      "dependencies": {
+        "@jest/get-type": "30.1.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/fake-timers": {
+      "version": "30.4.1",
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.4.1",
+        "@sinonjs/fake-timers": "^15.4.0",
+        "@types/node": "*",
+        "jest-message-util": "30.4.1",
+        "jest-mock": "30.4.1",
+        "jest-util": "30.4.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/get-type": {
+      "version": "30.1.0",
+      "license": "MIT",
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/globals": {
+      "version": "30.4.1",
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "30.4.1",
+        "@jest/expect": "30.4.1",
+        "@jest/types": "30.4.1",
+        "jest-mock": "30.4.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/pattern": {
+      "version": "30.4.0",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "jest-regex-util": "30.4.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/reporters": {
+      "version": "30.4.1",
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^0.2.3",
+        "@jest/console": "30.4.1",
+        "@jest/test-result": "30.4.1",
+        "@jest/transform": "30.4.1",
+        "@jest/types": "30.4.1",
+        "@jridgewell/trace-mapping": "^0.3.25",
+        "@types/node": "*",
+        "chalk": "^4.1.2",
+        "collect-v8-coverage": "^1.0.2",
+        "exit-x": "^0.2.2",
+        "glob": "^10.5.0",
+        "graceful-fs": "^4.2.11",
+        "istanbul-lib-coverage": "^3.0.0",
+        "istanbul-lib-instrument": "^6.0.0",
+        "istanbul-lib-report": "^3.0.0",
+        "istanbul-lib-source-maps": "^5.0.0",
+        "istanbul-reports": "^3.1.3",
+        "jest-message-util": "30.4.1",
+        "jest-util": "30.4.1",
+        "jest-worker": "30.4.1",
+        "slash": "^3.0.0",
+        "string-length": "^4.0.2",
+        "v8-to-istanbul": "^9.0.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@jest/reporters/node_modules/glob": {
+      "version": "10.5.0",
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@jest/reporters/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "license": "ISC"
+    },
+    "node_modules/@jest/reporters/node_modules/minimatch": {
+      "version": "9.0.9",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@jest/reporters/node_modules/path-scurry": {
+      "version": "1.11.1",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@jest/schemas": {
+      "version": "30.4.1",
+      "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.34.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/snapshot-utils": {
+      "version": "30.4.1",
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.4.1",
+        "chalk": "^4.1.2",
+        "graceful-fs": "^4.2.11",
+        "natural-compare": "^1.4.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/source-map": {
+      "version": "30.0.1",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.25",
+        "callsites": "^3.1.0",
+        "graceful-fs": "^4.2.11"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/test-result": {
+      "version": "30.4.1",
+      "license": "MIT",
+      "dependencies": {
+        "@jest/console": "30.4.1",
+        "@jest/types": "30.4.1",
+        "@types/istanbul-lib-coverage": "^2.0.6",
+        "collect-v8-coverage": "^1.0.2"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/test-sequencer": {
+      "version": "30.4.1",
+      "license": "MIT",
+      "dependencies": {
+        "@jest/test-result": "30.4.1",
+        "graceful-fs": "^4.2.11",
+        "jest-haste-map": "30.4.1",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/transform": {
+      "version": "30.4.1",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.27.4",
+        "@jest/types": "30.4.1",
+        "@jridgewell/trace-mapping": "^0.3.25",
+        "babel-plugin-istanbul": "^7.0.1",
+        "chalk": "^4.1.2",
+        "convert-source-map": "^2.0.0",
+        "fast-json-stable-stringify": "^2.1.0",
+        "graceful-fs": "^4.2.11",
+        "jest-haste-map": "30.4.1",
+        "jest-regex-util": "30.4.0",
+        "jest-util": "30.4.1",
+        "pirates": "^4.0.7",
+        "slash": "^3.0.0",
+        "write-file-atomic": "^5.0.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/types": {
+      "version": "30.4.1",
+      "license": "MIT",
+      "dependencies": {
+        "@jest/pattern": "30.4.0",
+        "@jest/schemas": "30.4.1",
+        "@types/istanbul-lib-coverage": "^2.0.6",
+        "@types/istanbul-reports": "^3.0.4",
+        "@types/node": "*",
+        "@types/yargs": "^17.0.33",
+        "chalk": "^4.1.2"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "license": "MIT"
     },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
     "node_modules/@ltd/j-toml": {
       "version": "1.38.0",
-      "resolved": "https://registry.npmjs.org/@ltd/j-toml/-/j-toml-1.38.0.tgz",
-      "integrity": "sha512-lYtBcmvHustHQtg4X7TXUu1Xa/tbLC3p2wLvgQI+fWVySguVZJF60Snxijw5EiohumxZbR10kWYFFebh1zotiw==",
       "license": "LGPL-3.0"
     },
     "node_modules/@noble/hashes": {
       "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
-      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
       "license": "MIT",
       "engines": {
         "node": "^14.21.3 || >=16"
@@ -1038,8 +1432,6 @@
     },
     "node_modules/@nodable/entities": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
-      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
       "funding": [
         {
           "type": "github",
@@ -1341,8 +1733,6 @@
     },
     "node_modules/@opentelemetry/api": {
       "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
-      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8.0.0"
@@ -1350,8 +1740,6 @@
     },
     "node_modules/@opentelemetry/api-logs": {
       "version": "0.214.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.214.0.tgz",
-      "integrity": "sha512-40lSJeqYO8Uz2Yj7u94/SJWE/wONa7rmMKjI1ZcIjgf3MHNHv1OZUCrCETGuaRF62d5pQD1wKIW+L4lmSMTzZA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api": "^1.3.0"
@@ -1362,8 +1750,6 @@
     },
     "node_modules/@opentelemetry/context-async-hooks": {
       "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-2.6.1.tgz",
-      "integrity": "sha512-XHzhwRNkBpeP8Fs/qjGrAf9r9PRv67wkJQ/7ZPaBQQ68DYlTBBx5MF9LvPx7mhuXcDessKK2b+DcxqwpgkcivQ==",
       "license": "Apache-2.0",
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
@@ -1374,8 +1760,6 @@
     },
     "node_modules/@opentelemetry/core": {
       "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.6.1.tgz",
-      "integrity": "sha512-8xHSGWpJP9wBxgBpnqGL0R3PbdWQndL1Qp50qrg71+B28zK5OQmUgcDKLJgzyAAV38t4tOyLMGDD60LneR5W8g==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.29.0"
@@ -1389,8 +1773,6 @@
     },
     "node_modules/@opentelemetry/exporter-trace-otlp-http": {
       "version": "0.214.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.214.0.tgz",
-      "integrity": "sha512-kIN8nTBMgV2hXzV/a20BCFilPZdAIMYYJGSgfMMRm/Xa+07y5hRDS2Vm12A/z8Cdu3Sq++ZvJfElokX2rkgGgw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "2.6.1",
@@ -1408,8 +1790,6 @@
     },
     "node_modules/@opentelemetry/otlp-exporter-base": {
       "version": "0.214.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.214.0.tgz",
-      "integrity": "sha512-u1Gdv0/E9wP+apqWf7Wv2npXmgJtxsW2XL0TEv9FZloTZRuMBKmu8cYVXwS4Hm3q/f/3FuCnPTgiwYvIqRSpRg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "2.6.1",
@@ -1424,8 +1804,6 @@
     },
     "node_modules/@opentelemetry/otlp-transformer": {
       "version": "0.214.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.214.0.tgz",
-      "integrity": "sha512-DSaYcuBRh6uozfsWN3R8HsN0yDhCuWP7tOFdkUOVaWD1KVJg8m4qiLUsg/tNhTLS9HUYUcwNpwL2eroLtsZZ/w==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api-logs": "0.214.0",
@@ -1445,8 +1823,6 @@
     },
     "node_modules/@opentelemetry/resources": {
       "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.6.1.tgz",
-      "integrity": "sha512-lID/vxSuKWXM55XhAKNoYXu9Cutoq5hFdkbTdI/zDKQktXzcWBVhNsOkiZFTMU9UtEWuGRNe0HUgmsFldIdxVA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "2.6.1",
@@ -1461,8 +1837,6 @@
     },
     "node_modules/@opentelemetry/sdk-logs": {
       "version": "0.214.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.214.0.tgz",
-      "integrity": "sha512-zf6acnScjhsaBUU22zXZ/sLWim1dfhUAbGXdMmHmNG3LfBnQ3DKsOCITb2IZwoUsNNMTogqFKBnlIPPftUgGwA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api-logs": "0.214.0",
@@ -1479,8 +1853,6 @@
     },
     "node_modules/@opentelemetry/sdk-metrics": {
       "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.6.1.tgz",
-      "integrity": "sha512-9t9hJHX15meBy2NmTJxL+NJfXmnausR2xUDvE19XQce0Qi/GBtDGamU8nS1RMbdgDmhgpm3VaOu2+fiS/SfTpQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "2.6.1",
@@ -1495,8 +1867,6 @@
     },
     "node_modules/@opentelemetry/sdk-trace-base": {
       "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.6.1.tgz",
-      "integrity": "sha512-r86ut4T1e8vNwB35CqCcKd45yzqH6/6Wzvpk2/cZB8PsPLlZFTvrh8yfOS3CYZYcUmAx4hHTZJ8AO8Dj8nrdhw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "2.6.1",
@@ -1512,8 +1882,6 @@
     },
     "node_modules/@opentelemetry/sdk-trace-node": {
       "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-2.6.1.tgz",
-      "integrity": "sha512-Hh2i4FwHWRFhnO2Q/p6svMxy8MPsNCG0uuzUY3glqm0rwM0nQvbTO1dXSp9OqQoTKXcQzaz9q1f65fsurmOhNw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/context-async-hooks": "2.6.1",
@@ -1529,8 +1897,6 @@
     },
     "node_modules/@opentelemetry/semantic-conventions": {
       "version": "1.40.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.40.0.tgz",
-      "integrity": "sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=14"
@@ -1540,34 +1906,42 @@
       "version": "1.1.0",
       "license": "MIT"
     },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@pkgr/core": {
+      "version": "0.3.6",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/pkgr"
+      }
+    },
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
-      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/base64": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
-      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/codegen": {
       "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
-      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/eventemitter": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
-      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/fetch": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
-      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.1"
@@ -1575,38 +1949,26 @@
     },
     "node_modules/@protobufjs/float": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
-      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/inquire": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.2.tgz",
-      "integrity": "sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/path": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
-      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/pool": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
-      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/utf8": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
-      "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@redocly/ajv": {
       "version": "8.18.3",
-      "resolved": "https://registry.npmjs.org/@redocly/ajv/-/ajv-8.18.3.tgz",
-      "integrity": "sha512-l42u0of3hY98sN2A+M4qTX1O/KrpgGH32Hu9kP2GtHyD5Dfqq86PKFLe5dwaD8DEnNmlOlll2BAmeEtf0DaySg==",
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -1621,8 +1983,6 @@
     },
     "node_modules/@redocly/cli": {
       "version": "2.30.6",
-      "resolved": "https://registry.npmjs.org/@redocly/cli/-/cli-2.30.6.tgz",
-      "integrity": "sha512-BFkviDxeuLbisRdaSfPmSehL0AIBGfA9mziZF0APumaFo92D2g+a3r25mPbhdD3EgmIKPZRvAe8AR8BudebVJA==",
       "license": "MIT",
       "dependencies": {
         "@opentelemetry/exporter-trace-otlp-http": "0.214.0",
@@ -1665,8 +2025,6 @@
     },
     "node_modules/@redocly/cli-otel": {
       "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@redocly/cli-otel/-/cli-otel-0.1.2.tgz",
-      "integrity": "sha512-Bg7BoO5t1x3lVK+KhA5aGPmeXpQmdf6WtTYHhelKJCsQ+tRMiJoFAQoKHoBHAoNxXrhlS3K9lKFLHGmtxsFQfA==",
       "license": "MIT",
       "dependencies": {
         "ulid": "^2.3.0"
@@ -1674,8 +2032,6 @@
     },
     "node_modules/@redocly/cli-otel/node_modules/ulid": {
       "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/ulid/-/ulid-2.4.0.tgz",
-      "integrity": "sha512-fIRiVTJNcSRmXKPZtGzFQv9WRrZ3M9eoptl/teFJvjOzmpU+/K/JH6HZ8deBfb5vMEpicJcLn7JmvdknlMq7Zg==",
       "license": "MIT",
       "bin": {
         "ulid": "bin/cli.js"
@@ -1684,8 +2040,6 @@
     "node_modules/@redocly/cli/node_modules/ajv": {
       "name": "@redocly/ajv",
       "version": "8.18.1",
-      "resolved": "https://registry.npmjs.org/@redocly/ajv/-/ajv-8.18.1.tgz",
-      "integrity": "sha512-Ifm/pP/tul1qmAecpbVxCBluVE32rKfjf8gYXH4xI2gCv9mRWFhJMHzkPDM4TXlxwPQYIFegymlsy8lXz7optA==",
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -1700,8 +2054,6 @@
     },
     "node_modules/@redocly/config": {
       "version": "0.48.2",
-      "resolved": "https://registry.npmjs.org/@redocly/config/-/config-0.48.2.tgz",
-      "integrity": "sha512-DUHthTRdj+caAQWCtJae4yzvxaUDuwQkFsZFVaAEyORd8Bt8K2wYso61jYZuR/kQZaDejfUREtQTVVZ5VYTqgw==",
       "license": "MIT",
       "dependencies": {
         "json-schema-to-ts": "2.7.2"
@@ -1709,8 +2061,6 @@
     },
     "node_modules/@redocly/openapi-core": {
       "version": "2.30.6",
-      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-2.30.6.tgz",
-      "integrity": "sha512-nxyqXRzWQQlvpLLv686ycOQg+fNWbF/ZvkyC8bXoDU6LxMM5qSjrNomcVwoExbNpvGt9qJilpT6qQlk155RnmA==",
       "license": "MIT",
       "dependencies": {
         "@redocly/ajv": "^8.18.1",
@@ -1732,8 +2082,6 @@
     "node_modules/@redocly/openapi-core/node_modules/ajv": {
       "name": "@redocly/ajv",
       "version": "8.18.1",
-      "resolved": "https://registry.npmjs.org/@redocly/ajv/-/ajv-8.18.1.tgz",
-      "integrity": "sha512-Ifm/pP/tul1qmAecpbVxCBluVE32rKfjf8gYXH4xI2gCv9mRWFhJMHzkPDM4TXlxwPQYIFegymlsy8lXz7optA==",
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -1748,8 +2096,6 @@
     },
     "node_modules/@redocly/respect-core": {
       "version": "2.30.6",
-      "resolved": "https://registry.npmjs.org/@redocly/respect-core/-/respect-core-2.30.6.tgz",
-      "integrity": "sha512-rE38QmhQ6EQNFR5Ry99oFXVL5q6D8W/CcyLGfdA/jf7Hv4fT/35M6Q6zONueC+j9N6fxbQC+Vvpd6JJKukrGFQ==",
       "license": "MIT",
       "dependencies": {
         "@faker-js/faker": "^7.6.0",
@@ -1773,8 +2119,6 @@
     "node_modules/@redocly/respect-core/node_modules/ajv": {
       "name": "@redocly/ajv",
       "version": "8.18.1",
-      "resolved": "https://registry.npmjs.org/@redocly/ajv/-/ajv-8.18.1.tgz",
-      "integrity": "sha512-Ifm/pP/tul1qmAecpbVxCBluVE32rKfjf8gYXH4xI2gCv9mRWFhJMHzkPDM4TXlxwPQYIFegymlsy8lXz7optA==",
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -1789,8 +2133,6 @@
     },
     "node_modules/@redocly/respect-core/node_modules/colorette": {
       "version": "2.0.20",
-      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
-      "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
       "license": "MIT"
     },
     "node_modules/@rollup/pluginutils": {
@@ -1841,8 +2183,6 @@
     },
     "node_modules/@shikijs/core": {
       "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-4.1.0.tgz",
-      "integrity": "sha512-jLJtSJeuFffqX6/inRE1zqU5aFv2hrszvYgq3OjbAgFRZiWv7abKMDdQzYxuSDfmUPQozZvI/kuy6VMTvnvqTQ==",
       "license": "MIT",
       "dependencies": {
         "@shikijs/primitive": "4.1.0",
@@ -1857,8 +2197,6 @@
     },
     "node_modules/@shikijs/engine-javascript": {
       "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-4.1.0.tgz",
-      "integrity": "sha512-YquhawCUgaBfhsS72e2Y/dI59gCBNPHu3fEO/tvLaXrTssxZrY5ddjtNLTwndrMgPo8b3IscE+xoICDzpTmlFQ==",
       "license": "MIT",
       "dependencies": {
         "@shikijs/types": "4.1.0",
@@ -1871,8 +2209,6 @@
     },
     "node_modules/@shikijs/engine-oniguruma": {
       "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-4.1.0.tgz",
-      "integrity": "sha512-axLpjVs45YBvvINa+dJF+NPW+KtFkNXsFr4SDw2BMj9GdeMnGxVB9PQb2xXlJYovslt/nz6giedAyOANkfc7hg==",
       "license": "MIT",
       "dependencies": {
         "@shikijs/types": "4.1.0",
@@ -1884,8 +2220,6 @@
     },
     "node_modules/@shikijs/langs": {
       "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-4.1.0.tgz",
-      "integrity": "sha512-nwOMruEkbgdZfQ/b8CgpNBVOpvG1k0N5tbmgiFeqsan401+x3ILqlzZJowSla4Agmq4hG2Uf2wh5jLTEhR8VSg==",
       "license": "MIT",
       "dependencies": {
         "@shikijs/types": "4.1.0"
@@ -1896,8 +2230,6 @@
     },
     "node_modules/@shikijs/primitive": {
       "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/primitive/-/primitive-4.1.0.tgz",
-      "integrity": "sha512-zx2/2Uwj2q9X3KSyYREEhXO23xBw5WUhP4orK2lE4r+t9JGITmEe0JH+wPmJhqHpOT2bRRs6lAL945+LDvOAGw==",
       "license": "MIT",
       "dependencies": {
         "@shikijs/types": "4.1.0",
@@ -1910,8 +2242,6 @@
     },
     "node_modules/@shikijs/themes": {
       "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-4.1.0.tgz",
-      "integrity": "sha512-emCcTnUM7yO2wltYbaxm+yLvcCI4+h8XBKc4KmJ7EZUXoSGjcCHifkI//R4OFit9ewpg7H2/9tjOuXrT2v/Knw==",
       "license": "MIT",
       "dependencies": {
         "@shikijs/types": "4.1.0"
@@ -1922,8 +2252,6 @@
     },
     "node_modules/@shikijs/types": {
       "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-4.1.0.tgz",
-      "integrity": "sha512-3EQWX54fMpniOrDblzAhiwiJwpiTMW6+B9DWyUd9ska483tbayFYuw47UxwuPknI31bKnySfVQ/QW+jFL4rFdA==",
       "license": "MIT",
       "dependencies": {
         "@shikijs/vscode-textmate": "^10.0.2",
@@ -1935,14 +2263,30 @@
     },
     "node_modules/@shikijs/vscode-textmate": {
       "version": "10.0.2",
-      "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
-      "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
       "license": "MIT"
     },
+    "node_modules/@sinclair/typebox": {
+      "version": "0.34.49",
+      "license": "MIT"
+    },
+    "node_modules/@sinonjs/commons": {
+      "version": "3.0.1",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "node_modules/@sinonjs/fake-timers": {
+      "version": "15.4.0",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1"
+      }
+    },
     "node_modules/@turbo/darwin-64": {
-      "version": "2.9.14",
-      "resolved": "https://registry.npmjs.org/@turbo/darwin-64/-/darwin-64-2.9.14.tgz",
-      "integrity": "sha512-t7QiPflaEyBE4oayeZtSmu4mEfjgIrcNlNNl1z1dmIVPqEdtA7+CfTf8d7KXsOGPh6aNgWjKxyvQg9uGfDQF+A==",
+      "version": "2.10.2",
+      "resolved": "https://registry.npmjs.org/@turbo/darwin-64/-/darwin-64-2.10.2.tgz",
+      "integrity": "sha512-wBM3ObqOWnKUDmg7QfUFDkDHPFUAJmrYlYqmEM8jMPAPA/I6wRJIbWimeQUqhOiQ8xPKhzyWM+xaiUP0wz8FEQ==",
       "cpu": [
         "x64"
       ],
@@ -1954,9 +2298,9 @@
       ]
     },
     "node_modules/@turbo/darwin-arm64": {
-      "version": "2.9.14",
-      "resolved": "https://registry.npmjs.org/@turbo/darwin-arm64/-/darwin-arm64-2.9.14.tgz",
-      "integrity": "sha512-d23147mC9BsCPA9mJ0h/ubcpbRgcJBXbcG3+Vq7YLhjz3IXuvQsJ1UXH8f4MD76ZjJ4m/E4aRdJV+MW88CDfbw==",
+      "version": "2.10.2",
+      "resolved": "https://registry.npmjs.org/@turbo/darwin-arm64/-/darwin-arm64-2.10.2.tgz",
+      "integrity": "sha512-/Cq0joWnuMjDPfhjbFP4sv+C/7gkQ415zlaO4XUzD5EZxbtrKgXKvuuydMvogG8GeUnN1aDltW71RlmEfpjbyw==",
       "cpu": [
         "arm64"
       ],
@@ -1968,9 +2312,9 @@
       ]
     },
     "node_modules/@turbo/linux-64": {
-      "version": "2.9.14",
-      "resolved": "https://registry.npmjs.org/@turbo/linux-64/-/linux-64-2.9.14.tgz",
-      "integrity": "sha512-P3ZKB5tuUDdDQWuAsACGUR1qv9W7BNWxdxqVJ0kZNuNNPRaVYTPPikLcp79+GiEcW3npsR+KyP38lnQiBc5aSA==",
+      "version": "2.10.2",
+      "resolved": "https://registry.npmjs.org/@turbo/linux-64/-/linux-64-2.10.2.tgz",
+      "integrity": "sha512-mMsf5IIhiKuceEXNstd25IbadjBXZ0amxzFOqliEzJX6HyeeHdBQPVSY583PWqYDyqM/FB8d5ZjkthfBSeuH3Q==",
       "cpu": [
         "x64"
       ],
@@ -1982,9 +2326,9 @@
       ]
     },
     "node_modules/@turbo/linux-arm64": {
-      "version": "2.9.14",
-      "resolved": "https://registry.npmjs.org/@turbo/linux-arm64/-/linux-arm64-2.9.14.tgz",
-      "integrity": "sha512-ZRTlzcUMrrPv9ZuDzRF9n60Ym13bKeG9jDB8WjxyLhWNzV+AJQN+zdpIk3NJYf2zQsGUm1mNar2P0elRzLw25g==",
+      "version": "2.10.2",
+      "resolved": "https://registry.npmjs.org/@turbo/linux-arm64/-/linux-arm64-2.10.2.tgz",
+      "integrity": "sha512-Wcng1i2kaKmXutmwxT9MUoYZvdaIekXAdlGr4+0TpgbhGLw7nDuEcRBFrxb5BbRoX1d1q8SpdRxLc45TvDZIdQ==",
       "cpu": [
         "arm64"
       ],
@@ -1996,9 +2340,9 @@
       ]
     },
     "node_modules/@turbo/windows-64": {
-      "version": "2.9.14",
-      "resolved": "https://registry.npmjs.org/@turbo/windows-64/-/windows-64-2.9.14.tgz",
-      "integrity": "sha512-exanwN6sIduZwykYeiTQj8kCmOhazP5WOz3bvXMcYtjhL6Z3iRWLewKrXCBq0bqwSP3iBMb/AerRCnHI4lx46A==",
+      "version": "2.10.2",
+      "resolved": "https://registry.npmjs.org/@turbo/windows-64/-/windows-64-2.10.2.tgz",
+      "integrity": "sha512-SsNhM7Ho7EpAdwtrJKBOic9Hso23vu6Dp0gAfLOvUFjPzurr/sGQlXZEvr6z89ne4RDOypTwz5CBDrixpMKtXw==",
       "cpu": [
         "x64"
       ],
@@ -2010,9 +2354,9 @@
       ]
     },
     "node_modules/@turbo/windows-arm64": {
-      "version": "2.9.14",
-      "resolved": "https://registry.npmjs.org/@turbo/windows-arm64/-/windows-arm64-2.9.14.tgz",
-      "integrity": "sha512-fVdCsnmYoKICsycbWuuGp6Jvi51/3G/UluFWuAUCvR8PIW5IJkAk5BM9UF8PSm0Q2IphWHFZjYEgjHsh3B9y/g==",
+      "version": "2.10.2",
+      "resolved": "https://registry.npmjs.org/@turbo/windows-arm64/-/windows-arm64-2.10.2.tgz",
+      "integrity": "sha512-Gf+S7ICAdimT/n02bOuVWKvhHnct/HYjZg3oBNIz5hZ9ZyWHbQim9J3P5Qip8WpX0ksxF7eaBVziJCuLnjhqDg==",
       "cpu": [
         "arm64"
       ],
@@ -2027,10 +2371,41 @@
       "version": "8.10.138",
       "license": "MIT"
     },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
     "node_modules/@types/debug": {
       "version": "4.1.13",
-      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
-      "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
       "license": "MIT",
       "dependencies": {
         "@types/ms": "*"
@@ -2047,12 +2422,38 @@
         "@types/unist": "*"
       }
     },
+    "node_modules/@types/istanbul-lib-coverage": {
+      "version": "2.0.6",
+      "license": "MIT"
+    },
+    "node_modules/@types/istanbul-lib-report": {
+      "version": "3.0.3",
+      "license": "MIT",
+      "dependencies": {
+        "@types/istanbul-lib-coverage": "*"
+      }
+    },
+    "node_modules/@types/istanbul-reports": {
+      "version": "3.0.4",
+      "license": "MIT",
+      "dependencies": {
+        "@types/istanbul-lib-report": "*"
+      }
+    },
+    "node_modules/@types/jest": {
+      "version": "30.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "expect": "^30.0.0",
+        "pretty-format": "^30.0.0"
+      }
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "license": "MIT"
     },
     "node_modules/@types/mdast": {
-      "version": "4.0.3",
+      "version": "4.0.4",
       "license": "MIT",
       "dependencies": {
         "@types/unist": "*"
@@ -2060,14 +2461,10 @@
     },
     "node_modules/@types/ms": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
-      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
       "license": "MIT"
     },
     "node_modules/@types/nlcst": {
       "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@types/nlcst/-/nlcst-2.0.3.tgz",
-      "integrity": "sha512-vSYNSDe6Ix3q+6Z7ri9lyWqgGhJTmzRjZRqyq15N0Z/1/UnVsno9G/N40NBijoYx2seFDIl0+B2mgAb9mezUCA==",
       "license": "MIT",
       "dependencies": {
         "@types/unist": "*"
@@ -2075,11 +2472,28 @@
     },
     "node_modules/@types/node": {
       "version": "25.9.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
-      "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
       "license": "MIT",
       "dependencies": {
         "undici-types": ">=7.24.0 <7.24.7"
+      }
+    },
+    "node_modules/@types/stack-utils": {
+      "version": "2.0.3",
+      "license": "MIT"
+    },
+    "node_modules/@types/tar": {
+      "version": "6.1.13",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "minipass": "^4.0.0"
+      }
+    },
+    "node_modules/@types/tar/node_modules/minipass": {
+      "version": "4.2.8",
+      "license": "ISC",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/@types/trusted-types": {
@@ -2091,6 +2505,17 @@
       "version": "3.0.2",
       "license": "MIT"
     },
+    "node_modules/@types/yargs": {
+      "version": "17.0.35",
+      "license": "MIT",
+      "dependencies": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "node_modules/@types/yargs-parser": {
+      "version": "21.0.3",
+      "license": "MIT"
+    },
     "node_modules/@types/yauzl": {
       "version": "2.10.3",
       "license": "MIT",
@@ -2100,13 +2525,33 @@
       }
     },
     "node_modules/@ungap/structured-clone": {
-      "version": "1.2.0",
+      "version": "1.3.2",
       "license": "ISC"
+    },
+    "node_modules/@unrs/resolver-binding-linux-x64-gnu": {
+      "version": "1.12.2",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-x64-musl": {
+      "version": "1.12.2",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
     },
     "node_modules/@volar/kit": {
       "version": "2.4.28",
-      "resolved": "https://registry.npmjs.org/@volar/kit/-/kit-2.4.28.tgz",
-      "integrity": "sha512-cKX4vK9dtZvDRaAzeoUdaAJEew6IdxHNCRrdp5Kvcl6zZOqb6jTOfk3kXkIkG3T7oTFXguEMt5+9ptyqYR84Pg==",
       "license": "MIT",
       "dependencies": {
         "@volar/language-service": "2.4.28",
@@ -2121,8 +2566,6 @@
     },
     "node_modules/@volar/language-core": {
       "version": "2.4.28",
-      "resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-2.4.28.tgz",
-      "integrity": "sha512-w4qhIJ8ZSitgLAkVay6AbcnC7gP3glYM3fYwKV3srj8m494E3xtrCv6E+bWviiK/8hs6e6t1ij1s2Endql7vzQ==",
       "license": "MIT",
       "dependencies": {
         "@volar/source-map": "2.4.28"
@@ -2130,8 +2573,6 @@
     },
     "node_modules/@volar/language-server": {
       "version": "2.4.28",
-      "resolved": "https://registry.npmjs.org/@volar/language-server/-/language-server-2.4.28.tgz",
-      "integrity": "sha512-NqcLnE5gERKuS4PUFwlhMxf6vqYo7hXtbMFbViXcbVkbZ905AIVWhnSo0ZNBC2V127H1/2zP7RvVOVnyITFfBw==",
       "license": "MIT",
       "dependencies": {
         "@volar/language-core": "2.4.28",
@@ -2147,8 +2588,6 @@
     },
     "node_modules/@volar/language-service": {
       "version": "2.4.28",
-      "resolved": "https://registry.npmjs.org/@volar/language-service/-/language-service-2.4.28.tgz",
-      "integrity": "sha512-Rh/wYCZJrI5vCwMk9xyw/Z+MsWxlJY1rmMZPsxUoJKfzIRjS/NF1NmnuEcrMbEVGja00aVpCsInJfixQTMdvLw==",
       "license": "MIT",
       "dependencies": {
         "@volar/language-core": "2.4.28",
@@ -2159,14 +2598,10 @@
     },
     "node_modules/@volar/source-map": {
       "version": "2.4.28",
-      "resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-2.4.28.tgz",
-      "integrity": "sha512-yX2BDBqJkRXfKw8my8VarTyjv48QwxdJtvRgUpNE5erCsgEUdI2DsLbpa+rOQVAJYshY99szEcRDmyHbF10ggQ==",
       "license": "MIT"
     },
     "node_modules/@volar/typescript": {
       "version": "2.4.28",
-      "resolved": "https://registry.npmjs.org/@volar/typescript/-/typescript-2.4.28.tgz",
-      "integrity": "sha512-Ja6yvWrbis2QtN4ClAKreeUZPVYMARDYZl9LMEv1iQ1QdepB6wn0jTRxA9MftYmYa4DQ4k/DaSZpFPUfxl8giw==",
       "license": "MIT",
       "dependencies": {
         "@volar/language-core": "2.4.28",
@@ -2176,8 +2611,6 @@
     },
     "node_modules/@vscode/emmet-helper": {
       "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@vscode/emmet-helper/-/emmet-helper-2.11.0.tgz",
-      "integrity": "sha512-QLxjQR3imPZPQltfbWRnHU6JecWTF1QSWhx3GAKQpslx7y3Dp6sIIXhKjiUJ/BR9FX8PVthjr9PD6pNwOJfAzw==",
       "license": "MIT",
       "dependencies": {
         "emmet": "^2.4.3",
@@ -2189,14 +2622,10 @@
     },
     "node_modules/@vscode/emmet-helper/node_modules/jsonc-parser": {
       "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-2.3.1.tgz",
-      "integrity": "sha512-H8jvkz1O50L3dMZCsLqiuB2tA7muqbSg1AtGEkN0leAqGjsUzDJir3Zwr02BhqdcITPg3ei3mZ+HjMocAknhhg==",
       "license": "MIT"
     },
     "node_modules/@vscode/l10n": {
       "version": "0.0.18",
-      "resolved": "https://registry.npmjs.org/@vscode/l10n/-/l10n-0.0.18.tgz",
-      "integrity": "sha512-KYSIHVmslkaCDyw013pphY+d7x1qV8IZupYfeIfzNA+nsaWHbn5uPuQRvdRFsa9zFzGeudPuoGoZ1Op4jrJXIQ==",
       "license": "MIT"
     },
     "node_modules/agent-base": {
@@ -2222,8 +2651,6 @@
     },
     "node_modules/ajv-draft-04": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/ajv-draft-04/-/ajv-draft-04-1.0.0.tgz",
-      "integrity": "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==",
       "license": "MIT",
       "peerDependencies": {
         "ajv": "^8.5.0"
@@ -2236,8 +2663,6 @@
     },
     "node_modules/ajv-formats": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
-      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.0.0"
@@ -2258,6 +2683,29 @@
         "node": ">=6"
       }
     },
+    "node_modules/ansi-escapes": {
+      "version": "4.3.2",
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^0.21.3"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ansi-escapes/node_modules/type-fest": {
+      "version": "0.21.3",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
       "license": "MIT",
@@ -2267,8 +2715,6 @@
     },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -2293,8 +2739,6 @@
     },
     "node_modules/anymatch/node_modules/picomatch": {
       "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
-      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -2316,8 +2760,6 @@
     },
     "node_modules/array-iterate": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/array-iterate/-/array-iterate-2.0.1.tgz",
-      "integrity": "sha512-I1jXZMjAgCMmxT4qxXfPXa6SthSoE8h6gkSI9BGGNv8mP8G/v0blc+qFnZu6K42vTOiuME596QaLO0TP3Lk0xg==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -2325,14 +2767,12 @@
       }
     },
     "node_modules/astro": {
-      "version": "6.3.7",
-      "resolved": "https://registry.npmjs.org/astro/-/astro-6.3.7.tgz",
-      "integrity": "sha512-zIeDRrI0qNgN1lcCjNqt6/IVCVej7VwSa326cO8uP9BOk1cg4QuffhLnOn2gCgWQr32/wxpSRFfXiLKHglu1Tw==",
+      "version": "6.4.6",
       "license": "MIT",
       "dependencies": {
         "@astrojs/compiler": "^4.0.0",
-        "@astrojs/internal-helpers": "0.9.1",
-        "@astrojs/markdown-remark": "7.1.2",
+        "@astrojs/internal-helpers": "0.10.0",
+        "@astrojs/markdown-remark": "7.2.0",
         "@astrojs/telemetry": "3.3.2",
         "@capsizecss/unpack": "^4.0.0",
         "@clack/prompts": "^1.1.0",
@@ -2344,7 +2784,7 @@
         "clsx": "^2.1.1",
         "common-ancestor-path": "^2.0.0",
         "cookie": "^1.1.1",
-        "devalue": "^5.6.3",
+        "devalue": "^5.8.1",
         "diff": "^8.0.3",
         "dset": "^3.1.4",
         "es-module-lexer": "^2.0.0",
@@ -2413,14 +2853,10 @@
     },
     "node_modules/astro/node_modules/@astrojs/compiler": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@astrojs/compiler/-/compiler-4.0.0.tgz",
-      "integrity": "sha512-eouss7G8ygdZqHuke033VMcVw5HTZUu+PXd/h06DGDUg/jt5btPYPqh66ENWw/mU78rBrf/oeC4oqoBwMtDMNA==",
       "license": "MIT"
     },
     "node_modules/astro/node_modules/commander": {
       "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
-      "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16"
@@ -2428,8 +2864,6 @@
     },
     "node_modules/astro/node_modules/cookie": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
-      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -2441,8 +2875,6 @@
     },
     "node_modules/astro/node_modules/get-tsconfig": {
       "version": "5.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-5.0.0-beta.4.tgz",
-      "integrity": "sha512-7nF7C9fIPFEMHgEMEfgIlO9wDdZ8CyHw27rWciFZfHvHDReIiPhsYuzPRXsfvBCqFy1l8RRyyWV7QLM+ZhUJsQ==",
       "license": "MIT",
       "dependencies": {
         "resolve-pkg-maps": "^1.0.0"
@@ -2456,8 +2888,6 @@
     },
     "node_modules/astro/node_modules/postcss": {
       "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
       "funding": [
         {
           "type": "opencollective",
@@ -2484,8 +2914,6 @@
     },
     "node_modules/astro/node_modules/svgo": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/svgo/-/svgo-4.0.1.tgz",
-      "integrity": "sha512-XDpWUOPC6FEibaLzjfe0ucaV0YrOjYotGJO1WpF0Zd+n6ZGEQUsSugaoLq9QkEZtAfQIxT42UChcssDVPP3+/w==",
       "license": "MIT",
       "dependencies": {
         "commander": "^11.1.0",
@@ -2509,8 +2937,6 @@
     },
     "node_modules/astro/node_modules/vite": {
       "version": "7.3.3",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.3.tgz",
-      "integrity": "sha512-/4XH147Ui7OGTjg3HbdWe5arnZQSbfuRzdr9Ec7TQi5I7R+ir0Rlc9GIvD4v0XZurELqA035KVXJXpR61xhiTA==",
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.27.0",
@@ -2583,8 +3009,6 @@
     },
     "node_modules/astro/node_modules/vitefu": {
       "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/vitefu/-/vitefu-1.1.3.tgz",
-      "integrity": "sha512-ub4okH7Z5KLjb6hDyjqrGXqWtWvoYdU3IGm/NorpgHncKoLTCfRIbvlhBm7r0YstIaQRYlp4yEbFqDcKSzXSSg==",
       "license": "MIT",
       "workspaces": [
         "tests/deps/*",
@@ -2602,11 +3026,44 @@
     },
     "node_modules/astro/node_modules/yargs-parser": {
       "version": "22.0.0",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
-      "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
       "license": "ISC",
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "1.16.1",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.16.0",
+        "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
+        "proxy-from-env": "^2.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/agent-base": {
+      "version": "6.0.2",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/axios/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/axobject-query": {
@@ -2614,6 +3071,90 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/babel-jest": {
+      "version": "30.4.1",
+      "license": "MIT",
+      "dependencies": {
+        "@jest/transform": "30.4.1",
+        "@types/babel__core": "^7.20.5",
+        "babel-plugin-istanbul": "^7.0.1",
+        "babel-preset-jest": "30.4.0",
+        "chalk": "^4.1.2",
+        "graceful-fs": "^4.2.11",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.11.0 || ^8.0.0-0"
+      }
+    },
+    "node_modules/babel-plugin-istanbul": {
+      "version": "7.0.1",
+      "license": "BSD-3-Clause",
+      "workspaces": [
+        "test/babel-8"
+      ],
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@istanbuljs/load-nyc-config": "^1.0.0",
+        "@istanbuljs/schema": "^0.1.3",
+        "istanbul-lib-instrument": "^6.0.2",
+        "test-exclude": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/babel-plugin-jest-hoist": {
+      "version": "30.4.0",
+      "license": "MIT",
+      "dependencies": {
+        "@types/babel__core": "^7.20.5"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/babel-preset-current-node-syntax": {
+      "version": "1.2.0",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/plugin-syntax-async-generators": "^7.8.4",
+        "@babel/plugin-syntax-bigint": "^7.8.3",
+        "@babel/plugin-syntax-class-properties": "^7.12.13",
+        "@babel/plugin-syntax-class-static-block": "^7.14.5",
+        "@babel/plugin-syntax-import-attributes": "^7.24.7",
+        "@babel/plugin-syntax-import-meta": "^7.10.4",
+        "@babel/plugin-syntax-json-strings": "^7.8.3",
+        "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4",
+        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
+        "@babel/plugin-syntax-numeric-separator": "^7.10.4",
+        "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
+        "@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
+        "@babel/plugin-syntax-optional-chaining": "^7.8.3",
+        "@babel/plugin-syntax-private-property-in-object": "^7.14.5",
+        "@babel/plugin-syntax-top-level-await": "^7.14.5"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0 || ^8.0.0-0"
+      }
+    },
+    "node_modules/babel-preset-jest": {
+      "version": "30.4.0",
+      "license": "MIT",
+      "dependencies": {
+        "babel-plugin-jest-hoist": "30.4.0",
+        "babel-preset-current-node-syntax": "^1.2.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.11.0 || ^8.0.0-beta.1"
       }
     },
     "node_modules/bail": {
@@ -2628,14 +3169,22 @@
       "version": "1.0.2",
       "license": "MIT"
     },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.38",
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/before-after-hook": {
       "version": "4.0.0",
       "license": "Apache-2.0"
     },
     "node_modules/better-ajv-errors": {
       "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/better-ajv-errors/-/better-ajv-errors-2.0.3.tgz",
-      "integrity": "sha512-t1vxUP+vYKsaYi/BbKo2K98nEAZmfi4sjwvmRT8aOPDzPJeAtLurfoIDazVkLILxO4K+Sw4YrLYnBQ46l6pePg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
@@ -2661,11 +3210,57 @@
     },
     "node_modules/brace-expansion": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.4",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.38",
+        "caniuse-lite": "^1.0.30001799",
+        "electron-to-chromium": "^1.5.376",
+        "node-releases": "^2.0.48",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/bs-logger": {
+      "version": "0.2.6",
+      "license": "MIT",
+      "dependencies": {
+        "fast-json-stable-stringify": "2.x"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/bser": {
+      "version": "2.1.1",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "node-int64": "^0.4.0"
       }
     },
     "node_modules/buffer-crc32": {
@@ -2675,9 +3270,38 @@
         "node": "*"
       }
     },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "license": "MIT"
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/call-me-maybe": {
       "version": "1.0.2",
       "license": "MIT"
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/camelcase": {
+      "version": "5.3.1",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/camelize": {
       "version": "1.0.1",
@@ -2686,10 +3310,26 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001799",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
     "node_modules/ccount": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
-      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -2698,8 +3338,6 @@
     },
     "node_modules/chalk": {
       "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -2714,8 +3352,6 @@
     },
     "node_modules/chalk/node_modules/supports-color": {
       "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -2728,10 +3364,15 @@
       "version": "5.4.4",
       "license": "MIT"
     },
+    "node_modules/char-regex": {
+      "version": "1.0.2",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/character-entities": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
-      "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -2740,8 +3381,6 @@
     },
     "node_modules/character-entities-html4": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
-      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -2750,8 +3389,6 @@
     },
     "node_modules/character-entities-legacy": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
-      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -2759,25 +3396,23 @@
       }
     },
     "node_modules/cheerio": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.2.0.tgz",
-      "integrity": "sha512-WDrybc/gKFpTYQutKIK6UvfcuxijIZfMfXaYm8NMsPQxSYvf+13fXUJ4rztGGbJcBQ/GF55gvrZ0Bc0bj/mqvg==",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "cheerio-select": "^2.1.0",
         "dom-serializer": "^2.0.0",
         "domhandler": "^5.0.3",
-        "domutils": "^3.2.2",
-        "encoding-sniffer": "^0.2.1",
-        "htmlparser2": "^10.1.0",
-        "parse5": "^7.3.0",
-        "parse5-htmlparser2-tree-adapter": "^7.1.0",
+        "domutils": "^3.1.0",
+        "encoding-sniffer": "^0.2.0",
+        "htmlparser2": "^9.1.0",
+        "parse5": "^7.1.2",
+        "parse5-htmlparser2-tree-adapter": "^7.0.0",
         "parse5-parser-stream": "^7.1.2",
-        "undici": "^7.19.0",
+        "undici": "^6.19.5",
         "whatwg-mimetype": "^4.0.0"
       },
       "engines": {
-        "node": ">=20.18.1"
+        "node": ">=18.17"
       },
       "funding": {
         "url": "https://github.com/cheeriojs/cheerio?sponsor=1"
@@ -2785,8 +3420,6 @@
     },
     "node_modules/cheerio-select": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-2.1.0.tgz",
-      "integrity": "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==",
       "license": "BSD-2-Clause",
       "dependencies": {
         "boolbase": "^1.0.0",
@@ -2800,28 +3433,15 @@
         "url": "https://github.com/sponsors/fb55"
       }
     },
-    "node_modules/cheerio/node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=20.18.1"
-      }
-    },
     "node_modules/chownr": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
-      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
-      "license": "BlueOak-1.0.0",
+      "version": "2.0.0",
+      "license": "ISC",
       "engines": {
-        "node": ">=18"
+        "node": ">=10"
       }
     },
     "node_modules/ci-info": {
       "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
-      "integrity": "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==",
       "funding": [
         {
           "type": "github",
@@ -2832,6 +3452,10 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/cjs-module-lexer": {
+      "version": "2.2.0",
+      "license": "MIT"
     },
     "node_modules/classnames": {
       "version": "2.5.1",
@@ -2868,6 +3492,18 @@
         "node": ">=6"
       }
     },
+    "node_modules/co": {
+      "version": "4.6.0",
+      "license": "MIT",
+      "engines": {
+        "iojs": ">= 1.0.0",
+        "node": ">= 0.12.0"
+      }
+    },
+    "node_modules/collect-v8-coverage": {
+      "version": "1.0.3",
+      "license": "MIT"
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "license": "MIT",
@@ -2886,6 +3522,16 @@
       "version": "1.4.0",
       "license": "MIT"
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/comma-separated-tokens": {
       "version": "2.0.3",
       "license": "MIT",
@@ -2903,15 +3549,21 @@
     },
     "node_modules/common-ancestor-path": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/common-ancestor-path/-/common-ancestor-path-2.0.0.tgz",
-      "integrity": "sha512-dnN3ibLeoRf2HNC+OlCiNc5d2zxbLJXOtiZUudNFSXZrNSydxcCsSpRzXwfu7BBWCIfHPw+xTayeBvJCP/D8Ng==",
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">= 18"
       }
     },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "license": "MIT"
+    },
     "node_modules/confbox": {
       "version": "0.1.8",
+      "license": "MIT"
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
       "license": "MIT"
     },
     "node_modules/cookie": {
@@ -2923,8 +3575,6 @@
     },
     "node_modules/cookie-es": {
       "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-1.2.3.tgz",
-      "integrity": "sha512-lXVyvUvrNXblMqzIRrxHb57UUVmqsSWlxqt3XIjCkUP0wDAf6uicO6KMbEgYrMNtEvWgWHwe42CKxPu9MYAnWw==",
       "license": "MIT"
     },
     "node_modules/core-js": {
@@ -2937,10 +3587,20 @@
         "url": "https://opencollective.com/core-js"
       }
     },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/crossws": {
       "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/crossws/-/crossws-0.3.5.tgz",
-      "integrity": "sha512-ojKiDvcmByhwa8YYqbQI/hg7MEU0NC03+pSdEq4ZUnZR9xXpwk7E43SMNGkn+JxJGPFtNvQ48+vV2p+P1ml5PA==",
       "license": "MIT",
       "dependencies": {
         "uncrypto": "^0.1.3"
@@ -2978,8 +3638,6 @@
     },
     "node_modules/css-tree": {
       "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
-      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
       "license": "MIT",
       "dependencies": {
         "mdn-data": "2.27.1",
@@ -3028,14 +3686,10 @@
     },
     "node_modules/csstype": {
       "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
-      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -3054,8 +3708,6 @@
     },
     "node_modules/decode-named-character-reference": {
       "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
-      "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
       "license": "MIT",
       "dependencies": {
         "character-entities": "^2.0.0"
@@ -3065,11 +3717,35 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/dedent": {
+      "version": "1.7.2",
+      "license": "MIT",
+      "peerDependencies": {
+        "babel-plugin-macros": "^3.1.0"
+      },
+      "peerDependenciesMeta": {
+        "babel-plugin-macros": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/defu": {
       "version": "6.1.7",
-      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.7.tgz",
-      "integrity": "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==",
       "license": "MIT"
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
     },
     "node_modules/dequal": {
       "version": "2.0.3",
@@ -3080,8 +3756,6 @@
     },
     "node_modules/destr": {
       "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/destr/-/destr-2.0.5.tgz",
-      "integrity": "sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==",
       "license": "MIT"
     },
     "node_modules/detect-libc": {
@@ -3092,10 +3766,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/detect-newline": {
+      "version": "3.1.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/devalue": {
       "version": "5.8.1",
-      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.8.1.tgz",
-      "integrity": "sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw==",
       "license": "MIT"
     },
     "node_modules/devlop": {
@@ -3111,8 +3790,6 @@
     },
     "node_modules/diff": {
       "version": "8.0.4",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
-      "integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
@@ -3155,17 +3832,13 @@
     },
     "node_modules/dompurify": {
       "version": "3.4.5",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.5.tgz",
-      "integrity": "sha512-OrwIBKsdNSVEeubdJ1HBv/wNENRM9ytAVCv7YXt//A3vPdVMNuACRqK9mXCGCBW2ln7BT/A4X0jXHo2Gu89miA==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/domutils": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
-      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "version": "3.1.0",
       "license": "BSD-2-Clause",
       "dependencies": {
         "dom-serializer": "^2.0.0",
@@ -3188,17 +3861,43 @@
     },
     "node_modules/dset": {
       "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/dset/-/dset-3.1.4.tgz",
-      "integrity": "sha512-2QF/g9/zTaPDc3BjNcVTGoBbXBgYfMTTceLaYcFJ/W9kggFUkhxD/hMEeuLKbugyef9SqAx8cpgwlIP/jinUTA==",
       "license": "MIT",
       "engines": {
         "node": ">=4"
       }
     },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "license": "MIT"
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.378",
+      "license": "ISC"
+    },
+    "node_modules/emittery": {
+      "version": "0.13.1",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/emittery?sponsor=1"
+      }
+    },
     "node_modules/emmet": {
       "version": "2.4.11",
-      "resolved": "https://registry.npmjs.org/emmet/-/emmet-2.4.11.tgz",
-      "integrity": "sha512-23QPJB3moh/U9sT4rQzGgeyyGIrcM+GH5uVYg2C6wZIxAIJq7Ng3QLT79tl8FUwDXhyq9SusfknOrofAKqvgyQ==",
       "license": "MIT",
       "workspaces": [
         "./packages/scanner",
@@ -3217,8 +3916,6 @@
     },
     "node_modules/encoding-sniffer": {
       "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/encoding-sniffer/-/encoding-sniffer-0.2.1.tgz",
-      "integrity": "sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==",
       "license": "MIT",
       "dependencies": {
         "iconv-lite": "^0.6.3",
@@ -3245,11 +3942,53 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
+    "node_modules/error-ex": {
+      "version": "1.3.4",
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/es-module-lexer": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
-      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
       "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/es6-promise": {
       "version": "3.3.1",
@@ -3257,8 +3996,6 @@
     },
     "node_modules/esbuild": {
       "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
-      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -3297,7 +4034,7 @@
       }
     },
     "node_modules/escalade": {
-      "version": "3.1.2",
+      "version": "3.2.0",
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -3305,8 +4042,6 @@
     },
     "node_modules/escape-string-regexp": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
-      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -3315,16 +4050,66 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/eventemitter3": {
       "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
-      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
       "license": "MIT"
     },
+    "node_modules/execa": {
+      "version": "5.1.1",
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.0",
+        "human-signals": "^2.1.0",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.1",
+        "onetime": "^5.1.2",
+        "signal-exit": "^3.0.3",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/exit-x": {
+      "version": "0.2.2",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/expect": {
+      "version": "30.4.1",
+      "license": "MIT",
+      "dependencies": {
+        "@jest/expect-utils": "30.4.1",
+        "@jest/get-type": "30.1.0",
+        "jest-matcher-utils": "30.4.1",
+        "jest-message-util": "30.4.1",
+        "jest-mock": "30.4.1",
+        "jest-util": "30.4.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
     "node_modules/exsolve": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.8.tgz",
-      "integrity": "sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==",
+      "version": "1.0.5",
       "license": "MIT"
     },
     "node_modules/extend": {
@@ -3378,8 +4163,10 @@
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
       "license": "MIT"
     },
     "node_modules/fast-safe-stringify": {
@@ -3388,14 +4175,10 @@
     },
     "node_modules/fast-string-truncated-width": {
       "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-3.0.3.tgz",
-      "integrity": "sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==",
       "license": "MIT"
     },
     "node_modules/fast-string-width": {
       "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/fast-string-width/-/fast-string-width-3.0.2.tgz",
-      "integrity": "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==",
       "license": "MIT",
       "dependencies": {
         "fast-string-truncated-width": "^3.0.2"
@@ -3403,8 +4186,6 @@
     },
     "node_modules/fast-uri": {
       "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "funding": [
         {
           "type": "github",
@@ -3419,8 +4200,6 @@
     },
     "node_modules/fast-wrap-ansi": {
       "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/fast-wrap-ansi/-/fast-wrap-ansi-0.2.2.tgz",
-      "integrity": "sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==",
       "license": "MIT",
       "dependencies": {
         "fast-string-width": "^3.0.2"
@@ -3428,8 +4207,6 @@
     },
     "node_modules/fast-xml-builder": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
-      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
       "funding": [
         {
           "type": "github",
@@ -3444,8 +4221,6 @@
     },
     "node_modules/fast-xml-parser": {
       "version": "5.8.0",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.8.0.tgz",
-      "integrity": "sha512-6bIM7fsJxeo3uXv7OncQYsBAMPJ7V16Slahl/6M98C/i2q+vB1+4a0MtrvYwDFEUrwDSbAmeLDRXsOBwrL7yAg==",
       "funding": [
         {
           "type": "github",
@@ -3464,6 +4239,13 @@
         "fxparser": "src/cli/cli.js"
       }
     },
+    "node_modules/fb-watchman": {
+      "version": "2.0.2",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bser": "2.1.1"
+      }
+    },
     "node_modules/fd-slicer": {
       "version": "1.1.0",
       "license": "MIT",
@@ -3473,8 +4255,6 @@
     },
     "node_modules/fdir": {
       "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
-      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
       "license": "MIT",
       "engines": {
         "node": ">=12.0.0"
@@ -3488,6 +4268,17 @@
         }
       }
     },
+    "node_modules/find-up": {
+      "version": "4.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/flattie": {
       "version": "1.1.1",
       "license": "MIT",
@@ -3495,10 +4286,26 @@
         "node": ">=8"
       }
     },
+    "node_modules/follow-redirects": {
+      "version": "1.16.0",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fontace": {
       "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/fontace/-/fontace-0.4.1.tgz",
-      "integrity": "sha512-lDMvbAzSnHmbYMTEld5qdtvNH2/pWpICOqpean9IgC7vUbUJc3k+k5Dokp85CegamqQpFbXf0rAVkbzpyTA8aw==",
       "license": "MIT",
       "dependencies": {
         "fontkitten": "^1.0.2"
@@ -3506,8 +4313,6 @@
     },
     "node_modules/fontkitten": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/fontkitten/-/fontkitten-1.0.3.tgz",
-      "integrity": "sha512-Wp1zXWPVUPBmfoa3Cqc9ctaKuzKAV6uLstRqlR56kSjplf5uAce+qeyYym7F+PHbGTk+tCEdkCW6RD7DX/gBZw==",
       "license": "MIT",
       "dependencies": {
         "tiny-inflate": "^1.0.3"
@@ -3520,22 +4325,84 @@
       "version": "2.0.6",
       "license": "MIT"
     },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/foreground-child/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/forgejo-js": {
       "version": "11.0.0",
       "license": "MIT"
     },
-    "node_modules/fsevents": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "hasInstallScript": true,
+    "node_modules/form-data": {
+      "version": "4.0.5",
       "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
       "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fs-minipass": {
+      "version": "2.1.0",
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/fs-minipass/node_modules/minipass": {
+      "version": "3.3.6",
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "license": "ISC"
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/get-caller-file": {
@@ -3545,10 +4412,58 @@
         "node": "6.* || 8.* || >= 10.*"
       }
     },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-package-type": {
+      "version": "0.1.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "6.0.1",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/get-tsconfig": {
       "version": "4.14.0",
-      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
-      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -3560,14 +4475,10 @@
     },
     "node_modules/github-slugger": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-2.0.0.tgz",
-      "integrity": "sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==",
       "license": "ISC"
     },
     "node_modules/glob": {
       "version": "13.0.6",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
-      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "minimatch": "^10.2.2",
@@ -3591,10 +4502,22 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "license": "ISC"
+    },
     "node_modules/h3": {
       "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/h3/-/h3-1.15.11.tgz",
-      "integrity": "sha512-L3THSe2MPeBwgIZVSH5zLdBBU90TOxarvhK9d04IDY2AmVS8j2Jz2LIWtwsGOU3lu2I5jCN7FNvVfY2+XyF+mg==",
       "license": "MIT",
       "dependencies": {
         "cookie-es": "^1.2.3",
@@ -3610,8 +4533,6 @@
     },
     "node_modules/handlebars": {
       "version": "4.7.9",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
-      "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
       "license": "MIT",
       "dependencies": {
         "minimist": "^1.2.5",
@@ -3631,17 +4552,46 @@
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/hast-util-from-html": {
       "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/hast-util-from-html/-/hast-util-from-html-2.0.3.tgz",
-      "integrity": "sha512-CUSRHXyKjzHov8yKsQjGOElXy/3EKpyX56ELnkHH34vDVw1N1XSQ1ZcAvTyAPtGqLTuKP/uxM+aLkSPqF/EtMw==",
       "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0",
@@ -3676,8 +4626,6 @@
     },
     "node_modules/hast-util-is-element": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-3.0.0.tgz",
-      "integrity": "sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g==",
       "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0"
@@ -3699,7 +4647,7 @@
       }
     },
     "node_modules/hast-util-raw": {
-      "version": "9.0.2",
+      "version": "9.1.0",
       "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0",
@@ -3723,8 +4671,6 @@
     },
     "node_modules/hast-util-to-html": {
       "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
-      "integrity": "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==",
       "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0",
@@ -3746,8 +4692,6 @@
     },
     "node_modules/hast-util-to-html/node_modules/property-information": {
       "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.1.0.tgz",
-      "integrity": "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -3755,13 +4699,13 @@
       }
     },
     "node_modules/hast-util-to-parse5": {
-      "version": "8.0.0",
+      "version": "8.0.1",
       "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0",
         "comma-separated-tokens": "^2.0.0",
         "devlop": "^1.0.0",
-        "property-information": "^6.0.0",
+        "property-information": "^7.0.0",
         "space-separated-tokens": "^2.0.0",
         "web-namespaces": "^2.0.0",
         "zwitch": "^2.0.0"
@@ -3771,10 +4715,16 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/hast-util-to-parse5/node_modules/property-information": {
+      "version": "7.2.0",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/hast-util-to-text": {
       "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/hast-util-to-text/-/hast-util-to-text-4.0.2.tgz",
-      "integrity": "sha512-KK6y/BN8lbaq654j7JgBydev7wuNMcID54lkRav1P0CaE1e47P72AWWPiGKXTJU271ooYzcvTAn/Zt0REnvc7A==",
       "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0",
@@ -3789,8 +4739,6 @@
     },
     "node_modules/hast-util-whitespace": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
-      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
       "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0"
@@ -3828,9 +4776,7 @@
       }
     },
     "node_modules/htmlparser2": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
-      "integrity": "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==",
+      "version": "9.1.0",
       "funding": [
         "https://github.com/fb55/htmlparser2?sponsor=1",
         {
@@ -3842,20 +4788,8 @@
       "dependencies": {
         "domelementtype": "^2.3.0",
         "domhandler": "^5.0.3",
-        "domutils": "^3.2.2",
-        "entities": "^7.0.1"
-      }
-    },
-    "node_modules/htmlparser2/node_modules/entities": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
-      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
+        "domutils": "^3.1.0",
+        "entities": "^4.5.0"
       }
     },
     "node_modules/http-cache-semantics": {
@@ -3877,16 +4811,45 @@
         "node": ">= 14"
       }
     },
+    "node_modules/human-signals": {
+      "version": "2.1.0",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.17.0"
+      }
+    },
     "node_modules/iconv-lite": {
       "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/import-local": {
+      "version": "3.2.0",
+      "license": "MIT",
+      "dependencies": {
+        "pkg-dir": "^4.2.0",
+        "resolve-cwd": "^3.0.0"
+      },
+      "bin": {
+        "import-local-fixture": "fixtures/cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
       }
     },
     "node_modules/index-to-position": {
@@ -3899,23 +4862,31 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "license": "ISC"
     },
     "node_modules/iron-webcrypto": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/iron-webcrypto/-/iron-webcrypto-1.2.1.tgz",
-      "integrity": "sha512-feOM6FaSr6rEABp/eDfVseKyTMDt+KGpeB35SkVn9Tyn0CqvVsY3EwI0v5i8nMHyJnzCIQf7nsy3p41TPkJZhg==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/brc-dd"
       }
     },
+    "node_modules/is-arrayish": {
+      "version": "0.2.1",
+      "license": "MIT"
+    },
     "node_modules/is-docker": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-4.0.0.tgz",
-      "integrity": "sha512-LHE+wROyG/Y/0ZnbktRCoTix2c1RhgWaZraMZ8o1Q7zCh0VSrICJQO5oqIIISrcSBtrXv0o233w1IYwsWCjTzA==",
       "license": "MIT",
       "bin": {
         "is-docker": "cli.js"
@@ -3934,10 +4905,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-generator-fn": {
+      "version": "2.1.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/is-inside-container": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
-      "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
       "license": "MIT",
       "dependencies": {
         "is-docker": "^3.0.0"
@@ -3954,8 +4930,6 @@
     },
     "node_modules/is-inside-container/node_modules/is-docker": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
-      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
       "license": "MIT",
       "bin": {
         "is-docker": "cli.js"
@@ -3977,10 +4951,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-wsl": {
       "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
-      "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
       "license": "MIT",
       "dependencies": {
         "is-inside-container": "^1.0.0"
@@ -3990,6 +4972,818 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "license": "ISC"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-instrument": {
+      "version": "6.0.3",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/core": "^7.23.9",
+        "@babel/parser": "^7.23.9",
+        "@istanbuljs/schema": "^0.1.3",
+        "istanbul-lib-coverage": "^3.2.0",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-report/node_modules/supports-color": {
+      "version": "7.2.0",
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "5.0.6",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.23",
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-reports/node_modules/html-escaper": {
+      "version": "2.0.2",
+      "license": "MIT"
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/jest": {
+      "version": "30.4.2",
+      "license": "MIT",
+      "dependencies": {
+        "@jest/core": "30.4.2",
+        "@jest/types": "30.4.1",
+        "import-local": "^3.2.0",
+        "jest-cli": "30.4.2"
+      },
+      "bin": {
+        "jest": "bin/jest.js"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-changed-files": {
+      "version": "30.4.1",
+      "license": "MIT",
+      "dependencies": {
+        "execa": "^5.1.1",
+        "jest-util": "30.4.1",
+        "p-limit": "^3.1.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-changed-files/node_modules/p-limit": {
+      "version": "3.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/jest-changed-files/node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/jest-circus": {
+      "version": "30.4.2",
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "30.4.1",
+        "@jest/expect": "30.4.1",
+        "@jest/test-result": "30.4.1",
+        "@jest/types": "30.4.1",
+        "@types/node": "*",
+        "chalk": "^4.1.2",
+        "co": "^4.6.0",
+        "dedent": "^1.6.0",
+        "is-generator-fn": "^2.1.0",
+        "jest-each": "30.4.1",
+        "jest-matcher-utils": "30.4.1",
+        "jest-message-util": "30.4.1",
+        "jest-runtime": "30.4.2",
+        "jest-snapshot": "30.4.1",
+        "jest-util": "30.4.1",
+        "p-limit": "^3.1.0",
+        "pretty-format": "30.4.1",
+        "pure-rand": "^7.0.0",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.6"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-circus/node_modules/p-limit": {
+      "version": "3.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/jest-circus/node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/jest-cli": {
+      "version": "30.4.2",
+      "license": "MIT",
+      "dependencies": {
+        "@jest/core": "30.4.2",
+        "@jest/test-result": "30.4.1",
+        "@jest/types": "30.4.1",
+        "chalk": "^4.1.2",
+        "exit-x": "^0.2.2",
+        "import-local": "^3.2.0",
+        "jest-config": "30.4.2",
+        "jest-util": "30.4.1",
+        "jest-validate": "30.4.1",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "jest": "bin/jest.js"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-cli/node_modules/cliui": {
+      "version": "8.0.1",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/jest-cli/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/jest-cli/node_modules/yargs": {
+      "version": "17.7.3",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/jest-config": {
+      "version": "30.4.2",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.27.4",
+        "@jest/get-type": "30.1.0",
+        "@jest/pattern": "30.4.0",
+        "@jest/test-sequencer": "30.4.1",
+        "@jest/types": "30.4.1",
+        "babel-jest": "30.4.1",
+        "chalk": "^4.1.2",
+        "ci-info": "^4.2.0",
+        "deepmerge": "^4.3.1",
+        "glob": "^10.5.0",
+        "graceful-fs": "^4.2.11",
+        "jest-circus": "30.4.2",
+        "jest-docblock": "30.4.0",
+        "jest-environment-node": "30.4.1",
+        "jest-regex-util": "30.4.0",
+        "jest-resolve": "30.4.1",
+        "jest-runner": "30.4.2",
+        "jest-util": "30.4.1",
+        "jest-validate": "30.4.1",
+        "parse-json": "^5.2.0",
+        "pretty-format": "30.4.1",
+        "slash": "^3.0.0",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@types/node": "*",
+        "esbuild-register": ">=3.4.0",
+        "ts-node": ">=9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "esbuild-register": {
+          "optional": true
+        },
+        "ts-node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-config/node_modules/glob": {
+      "version": "10.5.0",
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/jest-config/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "license": "ISC"
+    },
+    "node_modules/jest-config/node_modules/minimatch": {
+      "version": "9.0.9",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/jest-config/node_modules/parse-json": {
+      "version": "5.2.0",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/jest-config/node_modules/path-scurry": {
+      "version": "1.11.1",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/jest-diff": {
+      "version": "30.4.1",
+      "license": "MIT",
+      "dependencies": {
+        "@jest/diff-sequences": "30.4.0",
+        "@jest/get-type": "30.1.0",
+        "chalk": "^4.1.2",
+        "pretty-format": "30.4.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-docblock": {
+      "version": "30.4.0",
+      "license": "MIT",
+      "dependencies": {
+        "detect-newline": "^3.1.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-each": {
+      "version": "30.4.1",
+      "license": "MIT",
+      "dependencies": {
+        "@jest/get-type": "30.1.0",
+        "@jest/types": "30.4.1",
+        "chalk": "^4.1.2",
+        "jest-util": "30.4.1",
+        "pretty-format": "30.4.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-environment-node": {
+      "version": "30.4.1",
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "30.4.1",
+        "@jest/fake-timers": "30.4.1",
+        "@jest/types": "30.4.1",
+        "@types/node": "*",
+        "jest-mock": "30.4.1",
+        "jest-util": "30.4.1",
+        "jest-validate": "30.4.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-haste-map": {
+      "version": "30.4.1",
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.4.1",
+        "@types/node": "*",
+        "anymatch": "^3.1.3",
+        "fb-watchman": "^2.0.2",
+        "graceful-fs": "^4.2.11",
+        "jest-regex-util": "30.4.0",
+        "jest-util": "30.4.1",
+        "jest-worker": "30.4.1",
+        "picomatch": "^4.0.3",
+        "walker": "^1.0.8"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "^2.3.3"
+      }
+    },
+    "node_modules/jest-leak-detector": {
+      "version": "30.4.1",
+      "license": "MIT",
+      "dependencies": {
+        "@jest/get-type": "30.1.0",
+        "pretty-format": "30.4.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-matcher-utils": {
+      "version": "30.4.1",
+      "license": "MIT",
+      "dependencies": {
+        "@jest/get-type": "30.1.0",
+        "chalk": "^4.1.2",
+        "jest-diff": "30.4.1",
+        "pretty-format": "30.4.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-message-util": {
+      "version": "30.4.1",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.27.1",
+        "@jest/types": "30.4.1",
+        "@types/stack-utils": "^2.0.3",
+        "chalk": "^4.1.2",
+        "graceful-fs": "^4.2.11",
+        "jest-util": "30.4.1",
+        "picomatch": "^4.0.3",
+        "pretty-format": "30.4.1",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.6"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-mock": {
+      "version": "30.4.1",
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.4.1",
+        "@types/node": "*",
+        "jest-util": "30.4.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-pnp-resolver": {
+      "version": "1.2.3",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "peerDependencies": {
+        "jest-resolve": "*"
+      },
+      "peerDependenciesMeta": {
+        "jest-resolve": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-regex-util": {
+      "version": "30.4.0",
+      "license": "MIT",
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-resolve": {
+      "version": "30.4.1",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.2",
+        "graceful-fs": "^4.2.11",
+        "jest-haste-map": "30.4.1",
+        "jest-pnp-resolver": "^1.2.3",
+        "jest-util": "30.4.1",
+        "jest-validate": "30.4.1",
+        "slash": "^3.0.0",
+        "unrs-resolver": "^1.7.11"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-resolve-dependencies": {
+      "version": "30.4.2",
+      "license": "MIT",
+      "dependencies": {
+        "jest-regex-util": "30.4.0",
+        "jest-snapshot": "30.4.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-runner": {
+      "version": "30.4.2",
+      "license": "MIT",
+      "dependencies": {
+        "@jest/console": "30.4.1",
+        "@jest/environment": "30.4.1",
+        "@jest/test-result": "30.4.1",
+        "@jest/transform": "30.4.1",
+        "@jest/types": "30.4.1",
+        "@types/node": "*",
+        "chalk": "^4.1.2",
+        "emittery": "^0.13.1",
+        "exit-x": "^0.2.2",
+        "graceful-fs": "^4.2.11",
+        "jest-docblock": "30.4.0",
+        "jest-environment-node": "30.4.1",
+        "jest-haste-map": "30.4.1",
+        "jest-leak-detector": "30.4.1",
+        "jest-message-util": "30.4.1",
+        "jest-resolve": "30.4.1",
+        "jest-runtime": "30.4.2",
+        "jest-util": "30.4.1",
+        "jest-watcher": "30.4.1",
+        "jest-worker": "30.4.1",
+        "p-limit": "^3.1.0",
+        "source-map-support": "0.5.13"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-runner/node_modules/p-limit": {
+      "version": "3.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/jest-runner/node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/jest-runtime": {
+      "version": "30.4.2",
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "30.4.1",
+        "@jest/fake-timers": "30.4.1",
+        "@jest/globals": "30.4.1",
+        "@jest/source-map": "30.0.1",
+        "@jest/test-result": "30.4.1",
+        "@jest/transform": "30.4.1",
+        "@jest/types": "30.4.1",
+        "@types/node": "*",
+        "chalk": "^4.1.2",
+        "cjs-module-lexer": "^2.1.0",
+        "collect-v8-coverage": "^1.0.2",
+        "glob": "^10.5.0",
+        "graceful-fs": "^4.2.11",
+        "jest-haste-map": "30.4.1",
+        "jest-message-util": "30.4.1",
+        "jest-mock": "30.4.1",
+        "jest-regex-util": "30.4.0",
+        "jest-resolve": "30.4.1",
+        "jest-snapshot": "30.4.1",
+        "jest-util": "30.4.1",
+        "slash": "^3.0.0",
+        "strip-bom": "^4.0.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-runtime/node_modules/glob": {
+      "version": "10.5.0",
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/jest-runtime/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "license": "ISC"
+    },
+    "node_modules/jest-runtime/node_modules/minimatch": {
+      "version": "9.0.9",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/jest-runtime/node_modules/path-scurry": {
+      "version": "1.11.1",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/jest-snapshot": {
+      "version": "30.4.1",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.27.4",
+        "@babel/generator": "^7.27.5",
+        "@babel/plugin-syntax-jsx": "^7.27.1",
+        "@babel/plugin-syntax-typescript": "^7.27.1",
+        "@babel/types": "^7.27.3",
+        "@jest/expect-utils": "30.4.1",
+        "@jest/get-type": "30.1.0",
+        "@jest/snapshot-utils": "30.4.1",
+        "@jest/transform": "30.4.1",
+        "@jest/types": "30.4.1",
+        "babel-preset-current-node-syntax": "^1.2.0",
+        "chalk": "^4.1.2",
+        "expect": "30.4.1",
+        "graceful-fs": "^4.2.11",
+        "jest-diff": "30.4.1",
+        "jest-matcher-utils": "30.4.1",
+        "jest-message-util": "30.4.1",
+        "jest-util": "30.4.1",
+        "pretty-format": "30.4.1",
+        "semver": "^7.7.2",
+        "synckit": "^0.11.8"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-util": {
+      "version": "30.4.1",
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.4.1",
+        "@types/node": "*",
+        "chalk": "^4.1.2",
+        "ci-info": "^4.2.0",
+        "graceful-fs": "^4.2.11",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-validate": {
+      "version": "30.4.1",
+      "license": "MIT",
+      "dependencies": {
+        "@jest/get-type": "30.1.0",
+        "@jest/types": "30.4.1",
+        "camelcase": "^6.3.0",
+        "chalk": "^4.1.2",
+        "leven": "^3.1.0",
+        "pretty-format": "30.4.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-validate/node_modules/camelcase": {
+      "version": "6.3.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/jest-watcher": {
+      "version": "30.4.1",
+      "license": "MIT",
+      "dependencies": {
+        "@jest/test-result": "30.4.1",
+        "@jest/types": "30.4.1",
+        "@types/node": "*",
+        "ansi-escapes": "^4.3.2",
+        "chalk": "^4.1.2",
+        "emittery": "^0.13.1",
+        "jest-util": "30.4.1",
+        "string-length": "^4.0.2"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-worker": {
+      "version": "30.4.1",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@ungap/structured-clone": "^1.3.0",
+        "jest-util": "30.4.1",
+        "merge-stream": "^2.0.0",
+        "supports-color": "^8.1.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-worker/node_modules/supports-color": {
+      "version": "8.1.1",
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
     "node_modules/js-levenshtein": {
@@ -4005,8 +5799,6 @@
     },
     "node_modules/js-yaml": {
       "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -4014,6 +5806,20 @@
       "bin": {
         "js-yaml": "bin/js-yaml.js"
       }
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "license": "MIT"
     },
     "node_modules/json-pointer": {
       "version": "0.6.2",
@@ -4024,8 +5830,6 @@
     },
     "node_modules/json-schema-to-ts": {
       "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-2.7.2.tgz",
-      "integrity": "sha512-R1JfqKqbBR4qE8UyBR56Ms30LL62/nlhoz+1UkfI/VE7p54Awu919FZ6ZUPG8zIa3XB65usPJgr1ONVncUGSaQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.18.3",
@@ -4040,16 +5844,22 @@
       "version": "1.0.0",
       "license": "MIT"
     },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/jsonc-parser": {
       "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
-      "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
       "license": "MIT"
     },
     "node_modules/jsonpath-rfc9535": {
       "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/jsonpath-rfc9535/-/jsonpath-rfc9535-1.3.0.tgz",
-      "integrity": "sha512-3jFHya7oZ45aDxIIdx+/zQARahHXxFSMWBkcBUldfXpLS9VCXDJyTKt35kQfEXLqh0K3Ixw/9xFnvcDStaxh7Q==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=20"
@@ -4057,8 +5867,6 @@
     },
     "node_modules/jsonpointer": {
       "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-5.0.1.tgz",
-      "integrity": "sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -4077,22 +5885,21 @@
     },
     "node_modules/leven": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
-      "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
       "license": "MIT",
       "engines": {
         "node": ">=6"
       }
     },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "license": "MIT"
+    },
     "node_modules/local-pkg": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-1.2.1.tgz",
-      "integrity": "sha512-++gUqRDEvcnN6Zhqrr+y/CkVEHhlrR96vZn3nZZPYzMcBUyBtTKzB9NadClFIsIVSsu+3i9tfk/erqy9kAmt7Q==",
+      "version": "0.5.1",
       "license": "MIT",
       "dependencies": {
-        "mlly": "^1.7.4",
-        "pkg-types": "^2.3.0",
-        "quansync": "^0.2.11"
+        "mlly": "^1.7.3",
+        "pkg-types": "^1.2.1"
       },
       "engines": {
         "node": ">=14"
@@ -4101,33 +5908,26 @@
         "url": "https://github.com/sponsors/antfu"
       }
     },
-    "node_modules/local-pkg/node_modules/confbox": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.4.tgz",
-      "integrity": "sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==",
-      "license": "MIT"
-    },
-    "node_modules/local-pkg/node_modules/pkg-types": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.3.1.tgz",
-      "integrity": "sha512-y+ichcgc2LrADuhLNAx8DFjVfgz91pRxfZdI3UDhxHvcVEZsenLO+7XaU5vOp0u/7V/wZ+plyuQxtrDlZJ+yeg==",
+    "node_modules/locate-path": {
+      "version": "5.0.0",
       "license": "MIT",
       "dependencies": {
-        "confbox": "^0.2.4",
-        "exsolve": "^1.0.8",
-        "pathe": "^2.0.3"
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
+    },
+    "node_modules/lodash.memoize": {
+      "version": "4.1.2",
+      "license": "MIT"
     },
     "node_modules/long": {
       "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
-      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
       "license": "Apache-2.0"
     },
     "node_modules/longest-streak": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
-      "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -4146,8 +5946,6 @@
     },
     "node_modules/lru-cache": {
       "version": "11.5.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.0.tgz",
-      "integrity": "sha512-5YgH9UJd7wVb9hIouI2adWpgqrrICkt070Dnj8EUY1+B4B2P9eRLPAkAAo6NICA7CEhOIeBHl46u9zSNpNu7zA==",
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
@@ -4166,13 +5964,35 @@
     },
     "node_modules/magicast": {
       "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.3.tgz",
-      "integrity": "sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==",
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.29.3",
         "@babel/types": "^7.29.0",
         "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "license": "ISC"
+    },
+    "node_modules/makeerror": {
+      "version": "1.0.12",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tmpl": "1.0.5"
       }
     },
     "node_modules/mark.js": {
@@ -4181,8 +6001,6 @@
     },
     "node_modules/markdown-table": {
       "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
-      "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -4199,10 +6017,15 @@
         "node": ">= 12"
       }
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/mdast-util-definitions": {
       "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-definitions/-/mdast-util-definitions-6.0.0.tgz",
-      "integrity": "sha512-scTllyX6pnYNZH/AIp/0ePz6s4cZtARxImwoPJ7kS42n+MnVsI4XbnG6d4ibehRIldYMWM2LD7ImQblVhUejVQ==",
       "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.0",
@@ -4216,8 +6039,6 @@
     },
     "node_modules/mdast-util-find-and-replace": {
       "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
-      "integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
       "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.0",
@@ -4232,8 +6053,6 @@
     },
     "node_modules/mdast-util-from-markdown": {
       "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
-      "integrity": "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==",
       "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.0",
@@ -4256,8 +6075,6 @@
     },
     "node_modules/mdast-util-gfm": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
-      "integrity": "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==",
       "license": "MIT",
       "dependencies": {
         "mdast-util-from-markdown": "^2.0.0",
@@ -4275,8 +6092,6 @@
     },
     "node_modules/mdast-util-gfm-autolink-literal": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
-      "integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
       "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.0",
@@ -4292,8 +6107,6 @@
     },
     "node_modules/mdast-util-gfm-footnote": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
-      "integrity": "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==",
       "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.0",
@@ -4309,8 +6122,6 @@
     },
     "node_modules/mdast-util-gfm-strikethrough": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
-      "integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
       "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.0",
@@ -4324,8 +6135,6 @@
     },
     "node_modules/mdast-util-gfm-table": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
-      "integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
       "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.0",
@@ -4341,8 +6150,6 @@
     },
     "node_modules/mdast-util-gfm-task-list-item": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
-      "integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
       "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.0",
@@ -4357,8 +6164,6 @@
     },
     "node_modules/mdast-util-phrasing": {
       "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
-      "integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
       "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.0",
@@ -4390,8 +6195,6 @@
     },
     "node_modules/mdast-util-to-markdown": {
       "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
-      "integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
       "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.0",
@@ -4411,8 +6214,6 @@
     },
     "node_modules/mdast-util-to-string": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
-      "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
       "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.0"
@@ -4424,14 +6225,14 @@
     },
     "node_modules/mdn-data": {
       "version": "2.27.1",
-      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
-      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
       "license": "CC0-1.0"
+    },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "license": "MIT"
     },
     "node_modules/micromark": {
       "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
-      "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -4465,8 +6266,6 @@
     },
     "node_modules/micromark-core-commonmark": {
       "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
-      "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -4499,8 +6298,6 @@
     },
     "node_modules/micromark-extension-gfm": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
-      "integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
       "license": "MIT",
       "dependencies": {
         "micromark-extension-gfm-autolink-literal": "^2.0.0",
@@ -4519,8 +6316,6 @@
     },
     "node_modules/micromark-extension-gfm-autolink-literal": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
-      "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
       "license": "MIT",
       "dependencies": {
         "micromark-util-character": "^2.0.0",
@@ -4535,8 +6330,6 @@
     },
     "node_modules/micromark-extension-gfm-footnote": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
-      "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
       "license": "MIT",
       "dependencies": {
         "devlop": "^1.0.0",
@@ -4555,8 +6348,6 @@
     },
     "node_modules/micromark-extension-gfm-strikethrough": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
-      "integrity": "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==",
       "license": "MIT",
       "dependencies": {
         "devlop": "^1.0.0",
@@ -4573,8 +6364,6 @@
     },
     "node_modules/micromark-extension-gfm-table": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
-      "integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
       "license": "MIT",
       "dependencies": {
         "devlop": "^1.0.0",
@@ -4590,8 +6379,6 @@
     },
     "node_modules/micromark-extension-gfm-tagfilter": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
-      "integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
       "license": "MIT",
       "dependencies": {
         "micromark-util-types": "^2.0.0"
@@ -4603,8 +6390,6 @@
     },
     "node_modules/micromark-extension-gfm-task-list-item": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
-      "integrity": "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==",
       "license": "MIT",
       "dependencies": {
         "devlop": "^1.0.0",
@@ -4620,8 +6405,6 @@
     },
     "node_modules/micromark-factory-destination": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
-      "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -4641,8 +6424,6 @@
     },
     "node_modules/micromark-factory-label": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
-      "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -4663,8 +6444,6 @@
     },
     "node_modules/micromark-factory-space": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
-      "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -4683,8 +6462,6 @@
     },
     "node_modules/micromark-factory-title": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
-      "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -4705,8 +6482,6 @@
     },
     "node_modules/micromark-factory-whitespace": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
-      "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -4745,8 +6520,6 @@
     },
     "node_modules/micromark-util-chunked": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
-      "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -4764,8 +6537,6 @@
     },
     "node_modules/micromark-util-classify-character": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
-      "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -4785,8 +6556,6 @@
     },
     "node_modules/micromark-util-combine-extensions": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
-      "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -4805,8 +6574,6 @@
     },
     "node_modules/micromark-util-decode-numeric-character-reference": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
-      "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -4824,8 +6591,6 @@
     },
     "node_modules/micromark-util-decode-string": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
-      "integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -4860,8 +6625,6 @@
     },
     "node_modules/micromark-util-html-tag-name": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
-      "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -4876,8 +6639,6 @@
     },
     "node_modules/micromark-util-normalize-identifier": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
-      "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -4895,8 +6656,6 @@
     },
     "node_modules/micromark-util-resolve-all": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
-      "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -4933,8 +6692,6 @@
     },
     "node_modules/micromark-util-subtokenize": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
-      "integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -4981,10 +6738,32 @@
       ],
       "license": "MIT"
     },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/minimatch": {
       "version": "10.2.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
-      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "brace-expansion": "^5.0.5"
@@ -4998,8 +6777,6 @@
     },
     "node_modules/minimatch/node_modules/balanced-match": {
       "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
       "license": "MIT",
       "engines": {
         "node": "18 || 20 || >=22"
@@ -5007,8 +6784,6 @@
     },
     "node_modules/minimatch/node_modules/brace-expansion": {
       "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -5019,8 +6794,6 @@
     },
     "node_modules/minimist": {
       "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -5028,23 +6801,40 @@
     },
     "node_modules/minipass": {
       "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
-      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/minizlib": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
-      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
+      "version": "2.1.2",
       "license": "MIT",
       "dependencies": {
-        "minipass": "^7.1.2"
+        "minipass": "^3.0.0",
+        "yallist": "^4.0.0"
       },
       "engines": {
-        "node": ">= 18"
+        "node": ">= 8"
+      }
+    },
+    "node_modules/minizlib/node_modules/minipass": {
+      "version": "3.3.6",
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/mkdirp": {
+      "version": "1.0.4",
+      "license": "MIT",
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/mlly": {
@@ -5066,6 +6856,10 @@
       "engines": {
         "node": ">=0.4.0"
       }
+    },
+    "node_modules/mlly/node_modules/pathe": {
+      "version": "2.0.3",
+      "license": "MIT"
     },
     "node_modules/mobx": {
       "version": "6.13.7",
@@ -5130,20 +6924,14 @@
     },
     "node_modules/ms": {
       "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
     "node_modules/muggle-string": {
       "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/muggle-string/-/muggle-string-0.4.1.tgz",
-      "integrity": "sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==",
       "license": "MIT"
     },
     "node_modules/nanoid": {
       "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "funding": [
         {
           "type": "github",
@@ -5158,10 +6946,25 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/napi-postinstall": {
+      "version": "0.3.4",
+      "license": "MIT",
+      "bin": {
+        "napi-postinstall": "lib/cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/napi-postinstall"
+      }
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "license": "MIT"
+    },
     "node_modules/neo-async": {
       "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
-      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "license": "MIT"
     },
     "node_modules/neotraverse": {
@@ -5173,8 +6976,6 @@
     },
     "node_modules/nlcst-to-string": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/nlcst-to-string/-/nlcst-to-string-4.0.0.tgz",
-      "integrity": "sha512-YKLBCcUYKAg0FNlOBT6aI91qFmSiFKiluk655WzPF+DDMA02qIyy8uiRqI8QXtcFpEvll12LpL5MXqEmAZ+dcA==",
       "license": "MIT",
       "dependencies": {
         "@types/nlcst": "^2.0.0"
@@ -5214,14 +7015,14 @@
     },
     "node_modules/node-fetch-native": {
       "version": "1.6.7",
-      "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.7.tgz",
-      "integrity": "sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==",
+      "license": "MIT"
+    },
+    "node_modules/node-int64": {
+      "version": "0.4.0",
       "license": "MIT"
     },
     "node_modules/node-mock-http": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/node-mock-http/-/node-mock-http-1.0.4.tgz",
-      "integrity": "sha512-8DY+kFsDkNXy1sJglUfuODx1/opAGJGyrTuFqEoN90oRc2Vk0ZbD4K2qmKXBBEhZQzdKHIVfEJpDU8Ak2NJEvQ==",
       "license": "MIT"
     },
     "node_modules/node-readfiles": {
@@ -5231,11 +7032,28 @@
         "es6-promise": "^3.2.1"
       }
     },
+    "node_modules/node-releases": {
+      "version": "2.0.49",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/normalize-path": {
       "version": "3.0.0",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm-run-path": {
+      "version": "4.0.1",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/nth-check": {
@@ -5360,8 +7178,6 @@
     },
     "node_modules/obug": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
-      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
       "funding": [
         "https://github.com/sponsors/sxzz",
         "https://opencollective.com/debug"
@@ -5390,8 +7206,6 @@
     },
     "node_modules/ofetch": {
       "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/ofetch/-/ofetch-1.5.1.tgz",
-      "integrity": "sha512-2W4oUZlVaqAPAil6FUg/difl6YhqhUR7x2eZY4bQCko22UXg3hptq9KLQdqFClV+Wu85UX7hNtdGTngi/1BxcA==",
       "license": "MIT",
       "dependencies": {
         "destr": "^2.0.5",
@@ -5401,8 +7215,6 @@
     },
     "node_modules/ohash": {
       "version": "2.0.11",
-      "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
-      "integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
       "license": "MIT"
     },
     "node_modules/once": {
@@ -5412,16 +7224,25 @@
         "wrappy": "1"
       }
     },
+    "node_modules/onetime": {
+      "version": "5.1.2",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/oniguruma-parser": {
       "version": "0.12.2",
-      "resolved": "https://registry.npmjs.org/oniguruma-parser/-/oniguruma-parser-0.12.2.tgz",
-      "integrity": "sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw==",
       "license": "MIT"
     },
     "node_modules/oniguruma-to-es": {
       "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-4.3.6.tgz",
-      "integrity": "sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA==",
       "license": "MIT",
       "dependencies": {
         "oniguruma-parser": "^0.12.2",
@@ -5431,8 +7252,6 @@
     },
     "node_modules/openapi-sampler": {
       "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/openapi-sampler/-/openapi-sampler-1.7.3.tgz",
-      "integrity": "sha512-Qgy2+Z7xR3l7kXurtzi1PCtzAINkFKhBADBe/8cidC2fQrLUQTudLiJjQDnqJXoisWAR6zaHhC0hP6Hn5vja+g==",
       "license": "MIT",
       "dependencies": {
         "@types/json-schema": "^7.0.7",
@@ -5446,8 +7265,6 @@
     },
     "node_modules/openapi-typescript": {
       "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/openapi-typescript/-/openapi-typescript-7.13.0.tgz",
-      "integrity": "sha512-EFP392gcqXS7ntPvbhBzbF8TyBA+baIYEm791Hy5YkjDYKTnk/Tn5OQeKm5BIZvJihpp8Zzr4hzx0Irde1LNGQ==",
       "license": "MIT",
       "dependencies": {
         "@redocly/openapi-core": "^1.34.6",
@@ -5466,8 +7283,6 @@
     },
     "node_modules/openapi-typescript/node_modules/@redocly/ajv": {
       "version": "8.11.2",
-      "resolved": "https://registry.npmjs.org/@redocly/ajv/-/ajv-8.11.2.tgz",
-      "integrity": "sha512-io1JpnwtIcvojV7QKDUSIuMN/ikdOUd1ReEnUnMKGfDVridQZ31J0MmIuqwuRjWDZfmvr+Q0MqCcfHM2gTivOg==",
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
@@ -5482,14 +7297,10 @@
     },
     "node_modules/openapi-typescript/node_modules/@redocly/config": {
       "version": "0.22.0",
-      "resolved": "https://registry.npmjs.org/@redocly/config/-/config-0.22.0.tgz",
-      "integrity": "sha512-gAy93Ddo01Z3bHuVdPWfCwzgfaYgMdaZPcfL7JZ7hWJoK9V0lXDbigTWkhiPFAaLWzbOJ+kbUQG1+XwIm0KRGQ==",
       "license": "MIT"
     },
     "node_modules/openapi-typescript/node_modules/@redocly/openapi-core": {
       "version": "1.34.14",
-      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-1.34.14.tgz",
-      "integrity": "sha512-y+xFx+Zz54Xhr8jUdnLENYnt7Y7GEDL6Q03ga7rTtX8DVwefX9H+hQEPgJp1nda7vdH+wJ9/HBVvyfBuW9x6rA==",
       "license": "MIT",
       "dependencies": {
         "@redocly/ajv": "8.11.2",
@@ -5509,8 +7320,6 @@
     },
     "node_modules/openapi-typescript/node_modules/minimatch": {
       "version": "5.1.9",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
-      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.1"
@@ -5521,14 +7330,10 @@
     },
     "node_modules/outdent": {
       "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/outdent/-/outdent-0.8.0.tgz",
-      "integrity": "sha512-KiOAIsdpUTcAXuykya5fnVVT+/5uS0Q1mrkRHcF89tpieSmY33O/tmc54CqwA+bfhbtEfZUNLHaPUiB9X3jt1A==",
       "license": "MIT"
     },
     "node_modules/p-limit": {
       "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-7.3.0.tgz",
-      "integrity": "sha512-7cIXg/Z0M5WZRblrsOla88S4wAK+zOQQWeBYfV3qJuJXMr+LnbYjaadrFaS0JILfEDPVqHyKnZ1Z/1d6J9VVUw==",
       "license": "MIT",
       "dependencies": {
         "yocto-queue": "^1.2.1"
@@ -5540,10 +7345,31 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/p-locate": {
+      "version": "4.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-locate/node_modules/p-limit": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/p-queue": {
       "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-9.3.0.tgz",
-      "integrity": "sha512-7NED7xhQ74Ngp4JP/2e0VZHp7vSWfJfqeiR92jPgxsz6m0Se4P03YoTKa9dDXyZ3r6P616gUXttrB6nnHYKang==",
       "license": "MIT",
       "dependencies": {
         "eventemitter3": "^5.0.4",
@@ -5558,8 +7384,6 @@
     },
     "node_modules/p-timeout": {
       "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-7.0.1.tgz",
-      "integrity": "sha512-AxTM2wDGORHGEkPCt8yqxOTMgpfbEHqF51f/5fJCmwFC3C/zNcGT63SymH2ttOAaiIws2zVg4+izQCjrakcwHg==",
       "license": "MIT",
       "engines": {
         "node": ">=20"
@@ -5568,10 +7392,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "license": "BlueOak-1.0.0"
+    },
     "node_modules/package-manager-detector": {
       "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.6.0.tgz",
-      "integrity": "sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==",
       "license": "MIT"
     },
     "node_modules/parse-json": {
@@ -5591,8 +7424,6 @@
     },
     "node_modules/parse-latin": {
       "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/parse-latin/-/parse-latin-7.0.0.tgz",
-      "integrity": "sha512-mhHgobPPua5kZ98EF4HWiH167JWBfl4pvAIXXdbaVohtK7a6YBOy56kvhCqduqyo/f3yrHFWmqmiMg/BkBkYYQ==",
       "license": "MIT",
       "dependencies": {
         "@types/nlcst": "^2.0.0",
@@ -5608,24 +7439,20 @@
       }
     },
     "node_modules/parse5": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
-      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "version": "7.1.2",
       "license": "MIT",
       "dependencies": {
-        "entities": "^6.0.0"
+        "entities": "^4.4.0"
       },
       "funding": {
         "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
     "node_modules/parse5-htmlparser2-tree-adapter": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.1.0.tgz",
-      "integrity": "sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==",
+      "version": "7.0.0",
       "license": "MIT",
       "dependencies": {
-        "domhandler": "^5.0.3",
+        "domhandler": "^5.0.2",
         "parse5": "^7.0.0"
       },
       "funding": {
@@ -5634,8 +7461,6 @@
     },
     "node_modules/parse5-parser-stream": {
       "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/parse5-parser-stream/-/parse5-parser-stream-7.1.2.tgz",
-      "integrity": "sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==",
       "license": "MIT",
       "dependencies": {
         "parse5": "^7.0.0"
@@ -5644,26 +7469,19 @@
         "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
-    "node_modules/parse5/node_modules/entities": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
-      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
     "node_modules/path-browserify": {
       "version": "1.0.1",
       "license": "MIT"
     },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/path-expression-matcher": {
       "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
-      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
       "funding": [
         {
           "type": "github",
@@ -5675,10 +7493,22 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/path-scurry": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
-      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "lru-cache": "^11.0.0",
@@ -5692,9 +7522,7 @@
       }
     },
     "node_modules/pathe": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
-      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "version": "1.1.2",
       "license": "MIT"
     },
     "node_modules/pend": {
@@ -5707,26 +7535,37 @@
     },
     "node_modules/piccolore": {
       "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/piccolore/-/piccolore-0.1.3.tgz",
-      "integrity": "sha512-o8bTeDWjE086iwKrROaDf31K0qC/BENdm15/uH9usSC/uZjJOKb2YGiVHfLY4GhwsERiPI1jmwI2XrA7ACOxVw==",
       "license": "ISC"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
-      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "license": "ISC"
     },
     "node_modules/picomatch": {
       "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
       "engines": {
         "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pirates": {
+      "version": "4.0.7",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/pkg-dir": {
+      "version": "4.2.0",
+      "license": "MIT",
+      "dependencies": {
+        "find-up": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/pkg-types": {
@@ -5737,6 +7576,10 @@
         "mlly": "^1.7.4",
         "pathe": "^2.0.1"
       }
+    },
+    "node_modules/pkg-types/node_modules/pathe": {
+      "version": "2.0.3",
+      "license": "MIT"
     },
     "node_modules/pluralize": {
       "version": "8.0.0",
@@ -5785,10 +7628,31 @@
         "node": "^14.15.0 || >=16.0.0"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "30.4.1",
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "30.4.1",
+        "ansi-styles": "^5.2.0",
+        "react-is-18": "npm:react-is@^18.3.1",
+        "react-is-19": "npm:react-is@^19.2.5"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/prismjs": {
       "version": "1.30.0",
-      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz",
-      "integrity": "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==",
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -5813,8 +7677,6 @@
     },
     "node_modules/protobufjs": {
       "version": "7.6.1",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.1.tgz",
-      "integrity": "sha512-4K0myLaWL5EteuSAro91EGFgcfVgxb64Jx+7oDAY6GOkXD4M69yuSEljNcInGVCA5sOPxmZ/EqDLj2x0Q0+Ygg==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -5835,6 +7697,13 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/pump": {
       "version": "3.0.0",
       "license": "MIT",
@@ -5843,10 +7712,22 @@
         "once": "^1.3.1"
       }
     },
+    "node_modules/pure-rand": {
+      "version": "7.0.1",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/quansync": {
-      "version": "0.2.11",
-      "resolved": "https://registry.npmjs.org/quansync/-/quansync-0.2.11.tgz",
-      "integrity": "sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==",
+      "version": "0.2.10",
       "funding": [
         {
           "type": "individual",
@@ -5879,8 +7760,6 @@
     },
     "node_modules/radix3": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/radix3/-/radix3-1.1.2.tgz",
-      "integrity": "sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA==",
       "license": "MIT"
     },
     "node_modules/randombytes": {
@@ -5892,8 +7771,6 @@
     },
     "node_modules/react": {
       "version": "19.2.6",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
-      "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -5901,8 +7778,6 @@
     },
     "node_modules/react-dom": {
       "version": "19.2.6",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.6.tgz",
-      "integrity": "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==",
       "license": "MIT",
       "dependencies": {
         "scheduler": "^0.27.0"
@@ -5913,6 +7788,16 @@
     },
     "node_modules/react-is": {
       "version": "16.13.1",
+      "license": "MIT"
+    },
+    "node_modules/react-is-18": {
+      "name": "react-is",
+      "version": "18.3.1",
+      "license": "MIT"
+    },
+    "node_modules/react-is-19": {
+      "name": "react-is",
+      "version": "19.2.7",
       "license": "MIT"
     },
     "node_modules/react-tabs": {
@@ -6018,8 +7903,6 @@
     },
     "node_modules/regex": {
       "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/regex/-/regex-6.1.0.tgz",
-      "integrity": "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==",
       "license": "MIT",
       "dependencies": {
         "regex-utilities": "^2.3.0"
@@ -6027,8 +7910,6 @@
     },
     "node_modules/regex-recursion": {
       "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/regex-recursion/-/regex-recursion-6.0.2.tgz",
-      "integrity": "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==",
       "license": "MIT",
       "dependencies": {
         "regex-utilities": "^2.3.0"
@@ -6036,8 +7917,6 @@
     },
     "node_modules/regex-utilities": {
       "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/regex-utilities/-/regex-utilities-2.3.0.tgz",
-      "integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==",
       "license": "MIT"
     },
     "node_modules/rehype": {
@@ -6069,8 +7948,6 @@
     },
     "node_modules/rehype-raw": {
       "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/rehype-raw/-/rehype-raw-7.0.0.tgz",
-      "integrity": "sha512-/aE8hCfKlQeA8LmyeyQvQF3eBiLRGNlfBJEvWH7ivp9sBqs7TNqBL5X3v157rM4IFETqDnIOO+z5M/biZbo9Ww==",
       "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0",
@@ -6084,8 +7961,6 @@
     },
     "node_modules/rehype-stringify": {
       "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/rehype-stringify/-/rehype-stringify-10.0.1.tgz",
-      "integrity": "sha512-k9ecfXHmIPuFVI61B9DeLPN0qFHfawM6RsuX48hoqlaKSF61RskNjSm1lI8PhBEM0MRdLxVVm4WmTqJQccH9mA==",
       "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0",
@@ -6099,8 +7974,6 @@
     },
     "node_modules/remark-gfm": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
-      "integrity": "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==",
       "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.0",
@@ -6117,8 +7990,6 @@
     },
     "node_modules/remark-parse": {
       "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
-      "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
       "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.0",
@@ -6133,8 +8004,6 @@
     },
     "node_modules/remark-rehype": {
       "version": "11.1.2",
-      "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-11.1.2.tgz",
-      "integrity": "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==",
       "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0",
@@ -6150,8 +8019,6 @@
     },
     "node_modules/remark-smartypants": {
       "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/remark-smartypants/-/remark-smartypants-3.0.2.tgz",
-      "integrity": "sha512-ILTWeOriIluwEvPjv67v7Blgrcx+LZOkAUVtKI3putuhlZm84FnqDORNXPPm+HY3NdZOMhyDwZ1E+eZB/Df5dA==",
       "license": "MIT",
       "dependencies": {
         "retext": "^9.0.0",
@@ -6165,8 +8032,6 @@
     },
     "node_modules/remark-stringify": {
       "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
-      "integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
       "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.0",
@@ -6180,8 +8045,6 @@
     },
     "node_modules/request-light": {
       "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/request-light/-/request-light-0.7.0.tgz",
-      "integrity": "sha512-lMbBMrDoxgsyO+yB3sDcrDuX85yYt7sS8BfQd11jtbW/z5ZWgLZRcEGLsLoYw7I0WSUGQBs8CC8ScIxkTX1+6Q==",
       "license": "MIT"
     },
     "node_modules/require-directory": {
@@ -6198,10 +8061,25 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/resolve-cwd": {
+      "version": "3.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "resolve-from": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "5.0.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/resolve-pkg-maps": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
-      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
@@ -6209,8 +8087,6 @@
     },
     "node_modules/retext": {
       "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/retext/-/retext-9.0.0.tgz",
-      "integrity": "sha512-sbMDcpHCNjvlheSgMfEcVrZko3cDzdbe1x/e7G66dFp0Ff7Mldvi2uv6JkJQzdRcvLYE8CA8Oe8siQx8ZOgTcA==",
       "license": "MIT",
       "dependencies": {
         "@types/nlcst": "^2.0.0",
@@ -6225,8 +8101,6 @@
     },
     "node_modules/retext-latin": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/retext-latin/-/retext-latin-4.0.0.tgz",
-      "integrity": "sha512-hv9woG7Fy0M9IlRQloq/N6atV82NxLGveq+3H2WOi79dtIYWN8OaxogDm77f8YnVXJL2VD3bbqowu5E3EMhBYA==",
       "license": "MIT",
       "dependencies": {
         "@types/nlcst": "^2.0.0",
@@ -6240,8 +8114,6 @@
     },
     "node_modules/retext-smartypants": {
       "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/retext-smartypants/-/retext-smartypants-6.2.0.tgz",
-      "integrity": "sha512-kk0jOU7+zGv//kfjXEBjdIryL1Acl4i9XNkHxtM7Tm5lFiCog576fjNC9hjoR7LTKQ0DsPWy09JummSsH1uqfQ==",
       "license": "MIT",
       "dependencies": {
         "@types/nlcst": "^2.0.0",
@@ -6255,8 +8127,6 @@
     },
     "node_modules/retext-stringify": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/retext-stringify/-/retext-stringify-4.0.0.tgz",
-      "integrity": "sha512-rtfN/0o8kL1e+78+uxPTqu1Klt0yPzKuQ2BfWwwfgIUSayyzxpM1PJzkKt4V8803uB9qSy32MvI7Xep9khTpiA==",
       "license": "MIT",
       "dependencies": {
         "@types/nlcst": "^2.0.0",
@@ -6336,8 +8206,6 @@
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
     },
     "node_modules/sass-formatter": {
@@ -6350,8 +8218,6 @@
     },
     "node_modules/sax": {
       "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
-      "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=11.0.0"
@@ -6359,14 +8225,10 @@
     },
     "node_modules/scheduler": {
       "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
-      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "license": "MIT"
     },
     "node_modules/semver": {
       "version": "7.8.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
-      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -6420,10 +8282,25 @@
         "@img/sharp-win32-x64": "0.34.4"
       }
     },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/shiki": {
       "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/shiki/-/shiki-4.1.0.tgz",
-      "integrity": "sha512-l/ABZPUR5v70jI10EzqfMS/I96vjSGv2y0ihUV+WYFzv0EfvW4s54m0Lg8wCrrL+2IkwBzFTuxkZjPf8b2NX9Q==",
       "license": "MIT",
       "dependencies": {
         "@shikijs/core": "4.1.0",
@@ -6481,6 +8358,10 @@
       "version": "1.0.1",
       "license": "MIT"
     },
+    "node_modules/signal-exit": {
+      "version": "3.0.7",
+      "license": "ISC"
+    },
     "node_modules/simple-websocket": {
       "version": "9.1.0",
       "funding": [
@@ -6508,9 +8389,14 @@
     },
     "node_modules/sisteransi": {
       "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
-      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
       "license": "MIT"
+    },
+    "node_modules/slash": {
+      "version": "3.0.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/slugify": {
       "version": "1.4.7",
@@ -6521,8 +8407,6 @@
     },
     "node_modules/smol-toml": {
       "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.6.1.tgz",
-      "integrity": "sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">= 18"
@@ -6533,8 +8417,6 @@
     },
     "node_modules/source-map": {
       "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -6547,12 +8429,41 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/source-map-support": {
+      "version": "0.5.13",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
     "node_modules/space-separated-tokens": {
       "version": "2.0.2",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/stack-utils": {
+      "version": "2.0.6",
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/stack-utils/node_modules/escape-string-regexp": {
+      "version": "2.0.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/stickyfill": {
@@ -6563,6 +8474,17 @@
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/string-length": {
+      "version": "4.0.2",
+      "license": "MIT",
+      "dependencies": {
+        "char-regex": "^1.0.2",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/string-width": {
@@ -6577,10 +8499,21 @@
         "node": ">=8"
       }
     },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/stringify-entities": {
       "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
-      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
       "license": "MIT",
       "dependencies": {
         "character-entities-html4": "^2.0.0",
@@ -6601,10 +8534,43 @@
         "node": ">=8"
       }
     },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-bom": {
+      "version": "4.0.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-final-newline": {
+      "version": "2.0.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/strnum": {
       "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
-      "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
       "funding": [
         {
           "type": "github",
@@ -6615,8 +8581,6 @@
     },
     "node_modules/styled-components": {
       "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-6.4.1.tgz",
-      "integrity": "sha512-ADu2dF53esUzzM4I0ewxhxFtsDd6v4V6dNkg3vG0iFKhnt06sJneTZnRvujAosZwW0XD58IKgGMQoqri4wHRqg==",
       "license": "MIT",
       "dependencies": {
         "@emotion/is-prop-valid": "1.4.0",
@@ -6651,8 +8615,6 @@
     },
     "node_modules/stylis": {
       "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.3.6.tgz",
-      "integrity": "sha512-yQ3rwFWRfwNUY7H5vpU0wfdkNSnvnJinhF9830Swlaxl03zsOjCfmX0ugac+3LtK0lYSgwL/KXc8oYL3mG4YFQ==",
       "license": "MIT"
     },
     "node_modules/suf-log": {
@@ -6675,8 +8637,6 @@
     },
     "node_modules/svgo": {
       "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/svgo/-/svgo-3.3.3.tgz",
-      "integrity": "sha512-+wn7I4p7YgJhHs38k2TNjy1vCfPIfLIJWR5MnCStsN8WuuTcBnRKcMHQLMM2ijxGZmDoZwNv8ipl5aTTen62ng==",
       "license": "MIT",
       "dependencies": {
         "commander": "^7.2.0",
@@ -6781,20 +8741,87 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
-    "node_modules/tar": {
-      "version": "7.5.16",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.16.tgz",
-      "integrity": "sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==",
-      "license": "BlueOak-1.0.0",
+    "node_modules/synckit": {
+      "version": "0.11.13",
+      "license": "MIT",
       "dependencies": {
-        "@isaacs/fs-minipass": "^4.0.0",
-        "chownr": "^3.0.0",
-        "minipass": "^7.1.2",
-        "minizlib": "^3.1.0",
-        "yallist": "^5.0.0"
+        "@pkgr/core": "^0.3.6"
       },
       "engines": {
-        "node": ">=18"
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/synckit"
+      }
+    },
+    "node_modules/tar": {
+      "version": "6.2.1",
+      "license": "ISC",
+      "dependencies": {
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.0.0",
+        "minipass": "^5.0.0",
+        "minizlib": "^2.1.1",
+        "mkdirp": "^1.0.3",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/tar/node_modules/minipass": {
+      "version": "5.0.0",
+      "license": "ISC",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/test-exclude": {
+      "version": "6.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^7.1.4",
+        "minimatch": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/test-exclude/node_modules/brace-expansion": {
+      "version": "1.1.15",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/test-exclude/node_modules/glob": {
+      "version": "7.2.3",
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/test-exclude/node_modules/minimatch": {
+      "version": "3.1.5",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/tildagon-app": {
@@ -6811,14 +8838,10 @@
     },
     "node_modules/tiny-inflate": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
-      "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
       "license": "MIT"
     },
     "node_modules/tinyclip": {
       "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/tinyclip/-/tinyclip-0.1.12.tgz",
-      "integrity": "sha512-Ae3OVUqifDw0wBriIBS7yVaW44Dp6eSHQcyq4Igc7eN2TJH/2YsicswaW+J/OuMvhpDPOKEgpAZCjkb4hpoyeA==",
       "license": "MIT",
       "engines": {
         "node": "^16.14.0 || >= 17.3.0"
@@ -6826,8 +8849,6 @@
     },
     "node_modules/tinyexec": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.2.tgz",
-      "integrity": "sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -6835,8 +8856,6 @@
     },
     "node_modules/tinyglobby": {
       "version": "0.2.16",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
-      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
@@ -6849,11 +8868,23 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
+    "node_modules/tmpl": {
+      "version": "1.0.5",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/toad-cache": {
       "version": "3.7.0",
       "license": "MIT",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/toml": {
+      "version": "4.1.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/tr46": {
@@ -6878,14 +8909,60 @@
     },
     "node_modules/ts-algebra": {
       "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-1.2.2.tgz",
-      "integrity": "sha512-kloPhf1hq3JbCPOTYoOWDKxebWjNb2o/LKnNfkWhxVVisFFmMJPPdJeGoGmM+iRLyoXAR61e08Pb+vUXINg8aA==",
       "license": "MIT"
+    },
+    "node_modules/ts-jest": {
+      "version": "29.4.11",
+      "license": "MIT",
+      "dependencies": {
+        "bs-logger": "^0.2.6",
+        "fast-json-stable-stringify": "^2.1.0",
+        "handlebars": "^4.7.9",
+        "json5": "^2.2.3",
+        "lodash.memoize": "^4.1.2",
+        "make-error": "^1.3.6",
+        "semver": "^7.8.0",
+        "type-fest": "^4.41.0",
+        "yargs-parser": "^21.1.1"
+      },
+      "bin": {
+        "ts-jest": "cli.js"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || ^18.0.0 || >=20.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": ">=7.0.0-beta.0 <8",
+        "@jest/transform": "^29.0.0 || ^30.0.0",
+        "@jest/types": "^29.0.0 || ^30.0.0",
+        "babel-jest": "^29.0.0 || ^30.0.0",
+        "jest": "^29.0.0 || ^30.0.0",
+        "jest-util": "^29.0.0 || ^30.0.0",
+        "typescript": ">=4.3 <7"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        },
+        "@jest/transform": {
+          "optional": true
+        },
+        "@jest/types": {
+          "optional": true
+        },
+        "babel-jest": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jest-util": {
+          "optional": true
+        }
+      }
     },
     "node_modules/tsx": {
       "version": "4.21.0",
-      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
-      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -6903,21 +8980,28 @@
       }
     },
     "node_modules/turbo": {
-      "version": "2.9.14",
-      "resolved": "https://registry.npmjs.org/turbo/-/turbo-2.9.14.tgz",
-      "integrity": "sha512-BQqXRr4UoWI3UPFrtznCLykYHxwxWh53iCB57x092jPMjIlW1wnm3N895g5irpiXmnxUhREBB0n6+y8BHhs4nw==",
+      "version": "2.10.2",
+      "resolved": "https://registry.npmjs.org/turbo/-/turbo-2.10.2.tgz",
+      "integrity": "sha512-wTExrNrRjB8qzIcg+ZLm0A3GFNLDsWNwdS/RBXB0FPrBDyzk3i96Yx+TxWZC7a0k1SIreFB8ciUbxjmEqTH8IQ==",
       "dev": true,
       "license": "MIT",
       "bin": {
         "turbo": "bin/turbo"
       },
       "optionalDependencies": {
-        "@turbo/darwin-64": "2.9.14",
-        "@turbo/darwin-arm64": "2.9.14",
-        "@turbo/linux-64": "2.9.14",
-        "@turbo/linux-arm64": "2.9.14",
-        "@turbo/windows-64": "2.9.14",
-        "@turbo/windows-arm64": "2.9.14"
+        "@turbo/darwin-64": "2.10.2",
+        "@turbo/darwin-arm64": "2.10.2",
+        "@turbo/linux-64": "2.10.2",
+        "@turbo/linux-arm64": "2.10.2",
+        "@turbo/windows-64": "2.10.2",
+        "@turbo/windows-arm64": "2.10.2"
+      }
+    },
+    "node_modules/type-detect": {
+      "version": "4.0.8",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/type-fest": {
@@ -6932,8 +9016,6 @@
     },
     "node_modules/typesafe-path": {
       "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/typesafe-path/-/typesafe-path-0.2.2.tgz",
-      "integrity": "sha512-OJabfkAg1WLZSqJAJ0Z6Sdt3utnbzr/jh+NAHoyWHJe8CMSy79Gm085094M9nvTPy22KzTVn5Zq5mbapCI/hPA==",
       "license": "MIT"
     },
     "node_modules/typescript": {
@@ -6949,8 +9031,6 @@
     },
     "node_modules/typescript-auto-import-cache": {
       "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/typescript-auto-import-cache/-/typescript-auto-import-cache-0.3.6.tgz",
-      "integrity": "sha512-RpuHXrknHdVdK7wv/8ug3Fr0WNsNi5l5aB8MYYuXhq2UH5lnEB1htJ1smhtD5VeCsGr2p8mUDtd83LCQDFVgjQ==",
       "license": "MIT",
       "dependencies": {
         "semver": "^7.3.8"
@@ -6958,14 +9038,10 @@
     },
     "node_modules/ufo": {
       "version": "1.6.4",
-      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.4.tgz",
-      "integrity": "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==",
       "license": "MIT"
     },
     "node_modules/uglify-js": {
       "version": "3.19.3",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
-      "integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
       "license": "BSD-2-Clause",
       "optional": true,
       "bin": {
@@ -6977,8 +9053,6 @@
     },
     "node_modules/ulid": {
       "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/ulid/-/ulid-3.0.2.tgz",
-      "integrity": "sha512-yu26mwteFYzBAot7KVMqFGCVpsF6g8wXfJzQUHvu1no3+rRRSFcSV2nKeYvNPLD2J4b08jYBDhHUjeH0ygIl9w==",
       "license": "MIT",
       "bin": {
         "ulid": "dist/cli.js"
@@ -6990,14 +9064,10 @@
     },
     "node_modules/uncrypto": {
       "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.3.tgz",
-      "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==",
       "license": "MIT"
     },
     "node_modules/undici": {
       "version": "6.24.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.24.0.tgz",
-      "integrity": "sha512-lVLNosgqo5EkGqh5XUDhGfsMSoO8K0BAN0TyJLvwNRSl4xWGZlCVYsAIpa/OpA3TvmnM01GWcoKmc3ZWo5wKKA==",
       "license": "MIT",
       "engines": {
         "node": ">=18.17"
@@ -7005,14 +9075,10 @@
     },
     "node_modules/undici-types": {
       "version": "7.24.6",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
-      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
       "license": "MIT"
     },
     "node_modules/unified": {
       "version": "11.0.5",
-      "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
-      "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0",
@@ -7030,8 +9096,6 @@
     },
     "node_modules/unifont": {
       "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/unifont/-/unifont-0.7.4.tgz",
-      "integrity": "sha512-oHeis4/xl42HUIeHuNZRGEvxj5AaIKR+bHPNegRq5LV1gdc3jundpONbjglKpihmJf+dswygdMJn3eftGIMemg==",
       "license": "MIT",
       "dependencies": {
         "css-tree": "^3.1.0",
@@ -7041,8 +9105,6 @@
     },
     "node_modules/unist-util-find-after": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/unist-util-find-after/-/unist-util-find-after-5.0.0.tgz",
-      "integrity": "sha512-amQa0Ep2m6hE2g72AugUItjbuM8X8cGQnFoHk0pGfrFeT9GZhzN5SW8nRsiGKK7Aif4CrACPENkA6P/Lw6fHGQ==",
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0",
@@ -7066,8 +9128,6 @@
     },
     "node_modules/unist-util-modify-children": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/unist-util-modify-children/-/unist-util-modify-children-4.0.0.tgz",
-      "integrity": "sha512-+tdN5fGNddvsQdIzUF3Xx82CU9sMM+fA0dLgR9vOmT0oPT2jH+P1nd5lSqfCfXAw+93NhcXNY2qqvTUtE4cQkw==",
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0",
@@ -7091,8 +9151,6 @@
     },
     "node_modules/unist-util-remove-position": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-5.0.0.tgz",
-      "integrity": "sha512-Hp5Kh3wLxv0PHj9m2yZhhLt58KzPtEYKQQ4yxfYFEO7EvHwzyDYnduhHnY1mDxoqr7VUwVuHXk9RXKIiYS1N8Q==",
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0",
@@ -7116,8 +9174,6 @@
     },
     "node_modules/unist-util-visit": {
       "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
-      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0",
@@ -7131,8 +9187,6 @@
     },
     "node_modules/unist-util-visit-children": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/unist-util-visit-children/-/unist-util-visit-children-3.0.0.tgz",
-      "integrity": "sha512-RgmdTfSBOg04sdPcpTSD1jzoNBjt9a80/ZCzp5cI9n1qPzLZWF9YdvWGN2zmTumP1HWhXKdUWexjy/Wy/lJ7tA==",
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0"
@@ -7144,8 +9198,6 @@
     },
     "node_modules/unist-util-visit-parents": {
       "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
-      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0",
@@ -7164,10 +9216,43 @@
       "version": "7.0.3",
       "license": "ISC"
     },
+    "node_modules/unrs-resolver": {
+      "version": "1.12.2",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "napi-postinstall": "^0.3.4"
+      },
+      "funding": {
+        "url": "https://opencollective.com/unrs-resolver"
+      },
+      "optionalDependencies": {
+        "@unrs/resolver-binding-android-arm-eabi": "1.12.2",
+        "@unrs/resolver-binding-android-arm64": "1.12.2",
+        "@unrs/resolver-binding-darwin-arm64": "1.12.2",
+        "@unrs/resolver-binding-darwin-x64": "1.12.2",
+        "@unrs/resolver-binding-freebsd-x64": "1.12.2",
+        "@unrs/resolver-binding-linux-arm-gnueabihf": "1.12.2",
+        "@unrs/resolver-binding-linux-arm-musleabihf": "1.12.2",
+        "@unrs/resolver-binding-linux-arm64-gnu": "1.12.2",
+        "@unrs/resolver-binding-linux-arm64-musl": "1.12.2",
+        "@unrs/resolver-binding-linux-loong64-gnu": "1.12.2",
+        "@unrs/resolver-binding-linux-loong64-musl": "1.12.2",
+        "@unrs/resolver-binding-linux-ppc64-gnu": "1.12.2",
+        "@unrs/resolver-binding-linux-riscv64-gnu": "1.12.2",
+        "@unrs/resolver-binding-linux-riscv64-musl": "1.12.2",
+        "@unrs/resolver-binding-linux-s390x-gnu": "1.12.2",
+        "@unrs/resolver-binding-linux-x64-gnu": "1.12.2",
+        "@unrs/resolver-binding-linux-x64-musl": "1.12.2",
+        "@unrs/resolver-binding-openharmony-arm64": "1.12.2",
+        "@unrs/resolver-binding-wasm32-wasi": "1.12.2",
+        "@unrs/resolver-binding-win32-arm64-msvc": "1.12.2",
+        "@unrs/resolver-binding-win32-ia32-msvc": "1.12.2",
+        "@unrs/resolver-binding-win32-x64-msvc": "1.12.2"
+      }
+    },
     "node_modules/unstorage": {
       "version": "1.17.5",
-      "resolved": "https://registry.npmjs.org/unstorage/-/unstorage-1.17.5.tgz",
-      "integrity": "sha512-0i3iqvRfx29hkNntHyQvJTpf5W9dQ9ZadSoRU8+xVlhVtT7jAX57fazYO9EHvcRCfBCyi5YRya7XCDOsbTgkPg==",
       "license": "MIT",
       "dependencies": {
         "anymatch": "^3.1.3",
@@ -7262,8 +9347,6 @@
     },
     "node_modules/unstorage/node_modules/chokidar": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
-      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
       "license": "MIT",
       "dependencies": {
         "readdirp": "^5.0.0"
@@ -7277,8 +9360,6 @@
     },
     "node_modules/unstorage/node_modules/readdirp": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
-      "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 20.19.0"
@@ -7288,10 +9369,36 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
     "node_modules/uri-js-replace": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/uri-js-replace/-/uri-js-replace-1.0.1.tgz",
-      "integrity": "sha512-W+C9NWNLFOoBI2QWDp4UT9pv65r2w5Cx+3sTYFvtMdDBxkKt1syCqsUdSFAChbEe1uK5TfS04wt/nGwmaeIQ0g==",
       "license": "MIT"
     },
     "node_modules/url-template": {
@@ -7309,10 +9416,20 @@
       "version": "1.0.2",
       "license": "MIT"
     },
+    "node_modules/v8-to-istanbul": {
+      "version": "9.3.0",
+      "license": "ISC",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.12",
+        "@types/istanbul-lib-coverage": "^2.0.1",
+        "convert-source-map": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.12.0"
+      }
+    },
     "node_modules/vfile": {
       "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
-      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0",
@@ -7349,8 +9466,6 @@
     },
     "node_modules/volar-service-css": {
       "version": "0.0.70",
-      "resolved": "https://registry.npmjs.org/volar-service-css/-/volar-service-css-0.0.70.tgz",
-      "integrity": "sha512-K1qyOvBpE3rzdAv3e4/6Rv5yizrYPy5R/ne3IWCAzLBuMO4qBMV3kSqWzj6KUVe6S0AnN6wxF7cRkiaKfYMYJw==",
       "license": "MIT",
       "dependencies": {
         "vscode-css-languageservice": "^6.3.0",
@@ -7368,8 +9483,6 @@
     },
     "node_modules/volar-service-emmet": {
       "version": "0.0.70",
-      "resolved": "https://registry.npmjs.org/volar-service-emmet/-/volar-service-emmet-0.0.70.tgz",
-      "integrity": "sha512-xi5bC4m/VyE3zy/n2CXspKeDZs3qA41tHLTw275/7dNWM/RqE2z3BnDICQybHIVp/6G1iOQj5c1qXMgQC08TNg==",
       "license": "MIT",
       "dependencies": {
         "@emmetio/css-parser": "^0.4.1",
@@ -7388,8 +9501,6 @@
     },
     "node_modules/volar-service-html": {
       "version": "0.0.70",
-      "resolved": "https://registry.npmjs.org/volar-service-html/-/volar-service-html-0.0.70.tgz",
-      "integrity": "sha512-eR6vCgMdmYAo4n+gcT7DSyBQbwB8S3HZZvSagTf0sxNaD4WppMCFfpqWnkrlGStPKMZvMiejRRVmqsX9dYcTvQ==",
       "license": "MIT",
       "dependencies": {
         "vscode-html-languageservice": "^5.3.0",
@@ -7407,8 +9518,6 @@
     },
     "node_modules/volar-service-prettier": {
       "version": "0.0.70",
-      "resolved": "https://registry.npmjs.org/volar-service-prettier/-/volar-service-prettier-0.0.70.tgz",
-      "integrity": "sha512-Z6BCFSpGVCd8BPAsZ785Kce1BGlWd5ODqmqZGVuB14MJvrR4+CYz6cDy4F+igmE1gMifqfvMhdgT8Aud4M5ngg==",
       "license": "MIT",
       "dependencies": {
         "vscode-uri": "^3.0.8"
@@ -7428,8 +9537,6 @@
     },
     "node_modules/volar-service-typescript": {
       "version": "0.0.70",
-      "resolved": "https://registry.npmjs.org/volar-service-typescript/-/volar-service-typescript-0.0.70.tgz",
-      "integrity": "sha512-l46Bx4cokkUedTd74ojO5H/zqHZJ8SUuyZ0IB8JN4jfRqUM3bQFBHoOwlZCyZmOeO0A3RQNkMnFclxO4c++gsg==",
       "license": "MIT",
       "dependencies": {
         "path-browserify": "^1.0.1",
@@ -7450,8 +9557,6 @@
     },
     "node_modules/volar-service-typescript-twoslash-queries": {
       "version": "0.0.70",
-      "resolved": "https://registry.npmjs.org/volar-service-typescript-twoslash-queries/-/volar-service-typescript-twoslash-queries-0.0.70.tgz",
-      "integrity": "sha512-IdD13Z9N2Bu8EM6CM0fDV1E69olEYGHDU25X51YXmq8Y0CmJ2LNj6gOiBJgpS5JGUqFzECVhMNBW7R0sPdRTMQ==",
       "license": "MIT",
       "dependencies": {
         "vscode-uri": "^3.0.8"
@@ -7467,8 +9572,6 @@
     },
     "node_modules/volar-service-yaml": {
       "version": "0.0.70",
-      "resolved": "https://registry.npmjs.org/volar-service-yaml/-/volar-service-yaml-0.0.70.tgz",
-      "integrity": "sha512-0c8bXDBeoATF9F6iPIlOuYTuZAC4c+yi0siQo920u7eiBJk8oQmUmg9cDUbR4+Gl++bvGP4plj3fErbJuPqdcQ==",
       "license": "MIT",
       "dependencies": {
         "vscode-uri": "^3.0.8",
@@ -7485,8 +9588,6 @@
     },
     "node_modules/vscode-css-languageservice": {
       "version": "6.3.10",
-      "resolved": "https://registry.npmjs.org/vscode-css-languageservice/-/vscode-css-languageservice-6.3.10.tgz",
-      "integrity": "sha512-eq5N9Er3fC4vA9zd9EFhyBG90wtCCuXgRSpAndaOgXMh1Wgep5lBgRIeDgjZBW9pa+332yC9+49cZMW8jcL3MA==",
       "license": "MIT",
       "dependencies": {
         "@vscode/l10n": "^0.0.18",
@@ -7497,8 +9598,6 @@
     },
     "node_modules/vscode-html-languageservice": {
       "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/vscode-html-languageservice/-/vscode-html-languageservice-5.6.2.tgz",
-      "integrity": "sha512-ulCrSnFnfQ16YzvwnYUgEbUEl/ZG7u2eV27YhvLObSHKkb8fw1Z9cgsnUwjTEeDIdJDoTDTDpxuhQwoenoLNMg==",
       "license": "MIT",
       "dependencies": {
         "@vscode/l10n": "^0.0.18",
@@ -7509,8 +9608,6 @@
     },
     "node_modules/vscode-json-languageservice": {
       "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/vscode-json-languageservice/-/vscode-json-languageservice-4.1.8.tgz",
-      "integrity": "sha512-0vSpg6Xd9hfV+eZAaYN63xVVMOTmJ4GgHxXnkLCh+9RsQBkWKIghzLhW2B9ebfG+LQQg8uLtsQ2aUKjTgE+QOg==",
       "license": "MIT",
       "dependencies": {
         "jsonc-parser": "^3.0.0",
@@ -7525,8 +9622,6 @@
     },
     "node_modules/vscode-jsonrpc": {
       "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
-      "integrity": "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==",
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
@@ -7534,8 +9629,6 @@
     },
     "node_modules/vscode-languageserver": {
       "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-9.0.1.tgz",
-      "integrity": "sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g==",
       "license": "MIT",
       "dependencies": {
         "vscode-languageserver-protocol": "3.17.5"
@@ -7546,8 +9639,6 @@
     },
     "node_modules/vscode-languageserver-protocol": {
       "version": "3.17.5",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz",
-      "integrity": "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==",
       "license": "MIT",
       "dependencies": {
         "vscode-jsonrpc": "8.2.0",
@@ -7556,27 +9647,26 @@
     },
     "node_modules/vscode-languageserver-textdocument": {
       "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz",
-      "integrity": "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==",
       "license": "MIT"
     },
     "node_modules/vscode-languageserver-types": {
       "version": "3.17.5",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
-      "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==",
       "license": "MIT"
     },
     "node_modules/vscode-nls": {
       "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/vscode-nls/-/vscode-nls-5.2.0.tgz",
-      "integrity": "sha512-RAaHx7B14ZU04EU31pT+rKz2/zSl7xMsfIZuo8pd+KZO6PXtQmpevpq3vxvWNcrGbdmhM/rr5Uw5Mz+NBfhVng==",
       "license": "MIT"
     },
     "node_modules/vscode-uri": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
-      "integrity": "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==",
       "license": "MIT"
+    },
+    "node_modules/walker": {
+      "version": "1.0.8",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "makeerror": "1.0.12"
+      }
     },
     "node_modules/web-namespaces": {
       "version": "2.0.1",
@@ -7592,9 +9682,6 @@
     },
     "node_modules/whatwg-encoding": {
       "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
-      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
-      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
       "license": "MIT",
       "dependencies": {
         "iconv-lite": "0.6.3"
@@ -7605,8 +9692,6 @@
     },
     "node_modules/whatwg-mimetype": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
-      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -7620,10 +9705,21 @@
         "webidl-conversions": "^3.0.0"
       }
     },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/which-pm-runs": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.1.0.tgz",
-      "integrity": "sha512-n1brCuqClxfFfq/Rb0ICg9giSZqCS+pLtccdag6C2HyufBrh3fBOiy9nb6ggRMvWOVH5GrdJskj5iGTZNxd7SA==",
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -7631,13 +9727,115 @@
     },
     "node_modules/wordwrap": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
       "license": "MIT"
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi/node_modules/string-width": {
+      "version": "5.1.2",
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
     },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "license": "ISC"
+    },
+    "node_modules/write-file-atomic": {
+      "version": "5.0.1",
+      "license": "ISC",
+      "dependencies": {
+        "imurmurhash": "^0.1.4",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/write-file-atomic/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
     },
     "node_modules/ws": {
       "version": "7.5.10",
@@ -7660,8 +9858,6 @@
     },
     "node_modules/xml-naming": {
       "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
-      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
       "funding": [
         {
           "type": "github",
@@ -7685,13 +9881,8 @@
       }
     },
     "node_modules/yallist": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
-      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=18"
-      }
+      "version": "4.0.0",
+      "license": "ISC"
     },
     "node_modules/yaml": {
       "version": "1.10.2",
@@ -7706,8 +9897,6 @@
     },
     "node_modules/yaml-language-server": {
       "version": "1.20.0",
-      "resolved": "https://registry.npmjs.org/yaml-language-server/-/yaml-language-server-1.20.0.tgz",
-      "integrity": "sha512-qhjK/bzSRZ6HtTvgeFvjNPJGWdZ0+x5NREV/9XZWFjIGezew2b4r5JPy66IfOhd5OA7KeFwk1JfmEbnTvev0cA==",
       "license": "MIT",
       "dependencies": {
         "@vscode/l10n": "^0.0.18",
@@ -7728,14 +9917,10 @@
     },
     "node_modules/yaml-language-server/node_modules/request-light": {
       "version": "0.5.8",
-      "resolved": "https://registry.npmjs.org/request-light/-/request-light-0.5.8.tgz",
-      "integrity": "sha512-3Zjgh+8b5fhRJBQZoy+zbVKpAQGLyka0MPgW3zruTF4dFFJ8Fqcfu9YsAvi/rvdcaTeWG3MkbZv4WKxAn/84Lg==",
       "license": "MIT"
     },
     "node_modules/yaml-language-server/node_modules/yaml": {
       "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.1.tgz",
-      "integrity": "sha512-10ULxpnOCQXxJvBgxsn9ptjq6uviG/htZKk9veJGhlqn3w/DxQ631zFF+nlQXLwmImeS5amR2dl2U8sg6U9jsQ==",
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"
@@ -7784,8 +9969,6 @@
     },
     "node_modules/yocto-queue": {
       "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.2.tgz",
-      "integrity": "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==",
       "license": "MIT",
       "engines": {
         "node": ">=12.20"
@@ -7796,8 +9979,6 @@
     },
     "node_modules/zod": {
       "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
-      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
@@ -7822,7 +10003,14 @@
     },
     "packages/tildagon-app": {
       "dependencies": {
+        "@jest/globals": "^30.4.1",
+        "@types/jest": "^30.0.0",
+        "jest": "^30.4.2",
+        "ts-jest": "^29.4.11",
         "zod": "4.4.3"
+      },
+      "devDependencies": {
+        "toml": "^4.1.1"
       },
       "peerDependencies": {
         "typescript": "^5.0.0"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "0.0.1",
   "description": "App Store for Tildagon",
   "scripts": {
-    "start:web": "npm -w='tildagon-app-directory-site' run start"
+    "start:web": "npm -w='tildagon-app-directory-site' run start",
+    "test": "npm run --workspaces --if-present test"
   },
   "keywords": [
     "emfcamp",

--- a/packages/openapi-spec/tsconfig.json
+++ b/packages/openapi-spec/tsconfig.json
@@ -26,7 +26,7 @@
     // "moduleDetection": "auto",                        /* Control what method is used to detect module-format JS files. */
 
     /* Modules */
-    "module": "Node16" /* Specify what module code is generated. */,
+    "module": "node16" /* Specify what module code is generated. */,
     // "rootDir": "./" /* Specify the root folder within your source files. */,
     "moduleResolution": "node16",                     /* Specify how TypeScript looks up a file from a given module specifier. */
     // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */

--- a/packages/tildagon-app-directory-api/src/registries/sources/apps.json
+++ b/packages/tildagon-app-directory-api/src/registries/sources/apps.json
@@ -1,1 +1,1877 @@
-{"items":[{"code":"31434133","id":{"service":"github","owner":"jorants","title":"tildagon-acapp","releaseHash":"48582fe81f224127ac8471a51e13317fd37d98d0"},"releaseTime":"2024-06-01T22:27:09Z","tarballUrl":"https://codeload.github.com/jorants/tildagon-acapp/legacy.tar.gz/48582fe81f224127ac8471a51e13317fd37d98d0","manifest":{"app":{"name":"ACAB","category":"Badge"},"metadata":{"author":"Control-K & Bublebee","license":"LGPL-3.0-only","url":"https://github.com/controlkNL/tildagon-acapp","description":"Some flags and LED colors as images to customize your badge","version":"0.0.3"}}},{"code":"11023033","id":{"service":"github","owner":"proffalken","title":"tildagon-basic-api-demo","releaseHash":"a8c82af3573c656c108b8deba1d3ff00822cf3a2"},"releaseTime":"2024-06-01T11:33:25Z","tarballUrl":"https://codeload.github.com/proffalken/tildagon-basic-api-demo/legacy.tar.gz/a8c82af3573c656c108b8deba1d3ff00822cf3a2","manifest":{"app":{"name":"API Demo","category":"Badge"},"metadata":{"author":"proffalken","license":"MIT","url":"https://github.com/proffalken/tildagon-basic-api-demo","description":"A demo tildagon app for showing how to explore an api","version":"0.0.2"}}},{"code":"04211320","id":{"service":"github","owner":"mich181189","title":"Tildagon-ArtNet","releaseHash":"71e07f95efe7e5544246917b90394524e54b776d"},"releaseTime":"2024-07-07T10:29:40Z","tarballUrl":"https://codeload.github.com/mich181189/Tildagon-ArtNet/legacy.tar.gz/71e07f95efe7e5544246917b90394524e54b776d","manifest":{"app":{"name":"ArtNet Receiver","category":"Badge"},"metadata":{"author":"mich181189","license":"BSD-3-Clause","url":"https://github.com/mich181189/Tildagon-ArtNet","description":"An ArtNet receiver for your badge! Currently a little janky and hard-coded","version":"0.0.1"}}},{"code":"40334312","id":{"service":"github","owner":"sodoku","title":"tildagon-avatar","releaseHash":"e06c65bbfa8302c0a89995a9d5921a3bfee44617"},"releaseTime":"2025-09-12T16:22:21Z","tarballUrl":"https://codeload.github.com/sodoku/tildagon-avatar/legacy.tar.gz/e06c65bbfa8302c0a89995a9d5921a3bfee44617","manifest":{"app":{"name":"Avatar","category":"Badge"},"metadata":{"author":"sodoku","license":"LGPL-3.0-only","url":"https://www.github.com/sodoku/tildagon-avatar","description":"Display your github avatar","version":"0.0.2"}}},{"code":"03133120","id":{"service":"github","owner":"TeamRobotmad","title":"BadgeBot","releaseHash":"0e24a63c06c237bb62d21d1b9bdcc6d94c8e71c5"},"releaseTime":"2024-06-30T10:24:41Z","tarballUrl":"https://codeload.github.com/TeamRobotmad/BadgeBot/legacy.tar.gz/0e24a63c06c237bb62d21d1b9bdcc6d94c8e71c5","manifest":{"app":{"name":"BadgeBot","category":"Apps"},"metadata":{"author":"Team Robotmad","license":"LGPL-3.0-only","url":"https://www.github.com/TeamRobotmad/BadgeBot","description":"A demo tildagon app for use with Hex Drive hexpansion ","version":"1.2.0"}}},{"code":"30231433","id":{"service":"github","owner":"analogue-stick","title":"badgemon","releaseHash":"ec4fb81212834ce2fdca76fd138d386425284ad5"},"releaseTime":"2024-06-19T19:41:13Z","tarballUrl":"https://codeload.github.com/analogue-stick/badgemon/legacy.tar.gz/ec4fb81212834ce2fdca76fd138d386425284ad5","manifest":{"app":{"name":"Badgemon Green","category":"Games"},"metadata":{"author":"Analogue Stick","license":"CC-BY-NC-SA-4.0","url":"https://github.com/analogue-stick/badgemon","description":"A realworld creature collecting RPG for the Tildagon!","version":"1.0.6"}}},{"code":"12230221","id":{"service":"github","owner":"lucasjones","title":"pixelbadge","releaseHash":"3e9cadfd296289f948b087f302db8855217456cb"},"releaseTime":"2024-06-04T16:27:47Z","tarballUrl":"https://codeload.github.com/lucasjones/pixelbadge/legacy.tar.gz/3e9cadfd296289f948b087f302db8855217456cb","manifest":{"app":{"name":"BadgePixelArt","category":"Badge"},"metadata":{"author":"lucasjones","license":"","url":"https://www.github.com/lucasjones/pixelbadge","description":"Pixel art animations (+ upload your own at pixelbadge.xyz)","version":"1.0.14"}}},{"code":"10004212","id":{"service":"github","owner":"jake-walker","title":"tildagon-bar-app","releaseHash":"d48c116bbe2ad0a906499925bd43a853b504802b"},"releaseTime":"2024-06-01T12:09:26Z","tarballUrl":"https://codeload.github.com/jake-walker/tildagon-bar-app/legacy.tar.gz/d48c116bbe2ad0a906499925bd43a853b504802b","manifest":{"app":{"name":"Bar","category":"Apps"},"metadata":{"author":"jake-walker","license":"Unlicense","url":"https://github.com/jake-walker/tildagon-bar-app","description":"An app for browsing drinks available at the bars.","version":"0.0.3"}}},{"code":"33202231","id":{"service":"github","owner":"hughrawlinson","title":"tildagon-battery","releaseHash":"2dc035c6cdd4f6e0cb223d38f83b959d41f4f264"},"releaseTime":"2024-06-04T21:22:06Z","tarballUrl":"https://codeload.github.com/hughrawlinson/tildagon-battery/legacy.tar.gz/2dc035c6cdd4f6e0cb223d38f83b959d41f4f264","manifest":{"app":{"name":"Battery","category":"Badge"},"metadata":{"author":"hughrawlinson","license":"LGPL-3.0-only","url":"https://www.github.com/hughrawlinson/battery","description":"See badge battery state","version":"0.4.0"}}},{"code":"00411212","id":{"service":"github","owner":"MatthewWilkes","title":"battery-background","releaseHash":"e2a82146cad3c4f73b5b441b409250a64d26b420"},"releaseTime":"2025-08-31T08:29:37Z","tarballUrl":"https://codeload.github.com/MatthewWilkes/battery-background/legacy.tar.gz/e2a82146cad3c4f73b5b441b409250a64d26b420","manifest":{"app":{"name":"Battery Background","category":"Background"},"metadata":{"author":"MatthewWilkes","license":"LGPL-3.0-only","url":"https://www.github.com/matthewwilkes/battery-background","description":"Draw the battery state as part of the standard background","version":"1.0.1"}}},{"code":"00110200","id":{"service":"github","owner":"ChrisDick","title":"Tildagon-Battery-Icon","releaseHash":"ca8c85a0702ed148f5e79bd16fc5cc150e7bfdb7"},"releaseTime":"2025-09-14T21:13:04Z","tarballUrl":"https://codeload.github.com/ChrisDick/Tildagon-Battery-Icon/legacy.tar.gz/ca8c85a0702ed148f5e79bd16fc5cc150e7bfdb7","manifest":{"app":{"name":"Battery Icon","category":"Badge"},"metadata":{"author":"ChrisDick","license":"MIT","url":"https://www.github.com/ChrisDick/tildagone","description":"Battery level icon app.","version":"0.0.1"}}},{"code":"33343423","id":{"service":"github","owner":"emericklaw","title":"tildagon-app-battery-meter","releaseHash":"0fe7c12554453f2a43acc55a8bd61b817c9ecdd1"},"releaseTime":"2025-05-14T00:44:03Z","tarballUrl":"https://codeload.github.com/emericklaw/tildagon-app-battery-meter/legacy.tar.gz/0fe7c12554453f2a43acc55a8bd61b817c9ecdd1","manifest":{"app":{"name":"Battery Meter","category":"Apps"},"metadata":{"author":"Matt Emerick-Law","license":"MIT","url":"https://github.com/emericklaw/tildagon-app-battery-meter/","description":"Shows detailed information about the battery percentage, voltage levels and charging state.","version":"0.2.0"}}},{"code":"01121311","id":{"service":"github","owner":"cibomahto","title":"tildagon-batteryvoltage","releaseHash":"c0522c9a28123369b75ce0bca9087e8255963973"},"releaseTime":"2024-06-01T19:14:15Z","tarballUrl":"https://codeload.github.com/cibomahto/tildagon-batteryvoltage/legacy.tar.gz/c0522c9a28123369b75ce0bca9087e8255963973","manifest":{"app":{"name":"Battery Voltage","category":"Badge"},"metadata":{"author":"cibomahto","license":"LGPL-3.0-only","url":"https://github.com/cibomahto/tildagon-batteryvoltage","description":"Check the battery voltage","version":"0.0.1"}}},{"code":"01414142","id":{"service":"github","owner":"archey347","title":"tildagon-app-scouts","releaseHash":"05c4a494363e4fec995cd0261efad210dcc416fd"},"releaseTime":"2024-10-04T00:42:47Z","tarballUrl":"https://codeload.github.com/archey347/tildagon-app-scouts/legacy.tar.gz/05c4a494363e4fec995cd0261efad210dcc416fd","manifest":{"app":{"name":"BEAST CAMP","category":"Apps"},"metadata":{"author":"archey347","license":"LGPL-3.0-only","url":"https://www.github.com/archey347/tildagon-app-scouts","description":"An app for BEAST camp 2024!","version":"0.2.2"}}},{"code":"01033103","id":{"service":"github","owner":"PaperclipBadger","title":"badgebattery","releaseHash":"fd31ff84a6525290abcbebb493f23c133c861613"},"releaseTime":"2024-06-02T01:47:16Z","tarballUrl":"https://codeload.github.com/PaperclipBadger/badgebattery/legacy.tar.gz/fd31ff84a6525290abcbebb493f23c133c861613","manifest":{"app":{"name":"Blaine's Battery","category":"Badge"},"metadata":{"author":"Blaine","license":"MIT","url":"https://github.com/paperclipbadger/badgebattery","description":"A battery app that works!","version":"0.1"}}},{"code":"44210304","id":{"service":"github","owner":"PaperclipBadger","title":"badgeclock","releaseHash":"8135377844522af727b717f6155da5c6f0ee12f0"},"releaseTime":"2024-06-02T13:46:54Z","tarballUrl":"https://codeload.github.com/PaperclipBadger/badgeclock/legacy.tar.gz/8135377844522af727b717f6155da5c6f0ee12f0","manifest":{"app":{"name":"Blaine's Clock","category":"Badge"},"metadata":{"author":"Blaine","license":"MIT","url":"https://github.com/paperclipbadger/badgeclock","description":"An analogue clock that usually doesn't crash!","version":"0.8"}}},{"code":"41334402","id":{"service":"github","owner":"ritesh","title":"tildagon-bling","releaseHash":"5e15bdd73a44103303b37511b839a56680afe7cd"},"releaseTime":"2024-06-01T06:50:34Z","tarballUrl":"https://codeload.github.com/ritesh/tildagon-bling/legacy.tar.gz/5e15bdd73a44103303b37511b839a56680afe7cd","manifest":{"app":{"name":"Bling!","category":"Apps"},"metadata":{"author":"ritesh","license":"WTFPL","url":"https://www.github.com/ritesh/tildagon-bling","description":"A silly app that makes your badge blingy!","version":"0.0.1"}}},{"code":"12132220","id":{"service":"github","owner":"npentrel","title":"tildagon-breadboard-tester","releaseHash":"dc5295fa9e1dc4813c5b0460ba73da31db5deb3f"},"releaseTime":"2024-08-04T13:13:06Z","tarballUrl":"https://codeload.github.com/npentrel/tildagon-breadboard-tester/legacy.tar.gz/dc5295fa9e1dc4813c5b0460ba73da31db5deb3f","manifest":{"app":{"name":"Breadboard Tester","category":"Apps"},"metadata":{"author":"naomi","license":"LGPL-3.0-only","url":"https://www.github.com/npentrel/tildagon-breadboard-tester","description":"Use only with breadboard hexpansions. Toggle the state of eGPIO and GPIO pins.","version":"0.0.2"}}},{"code":"42032113","id":{"service":"github","owner":"merlininthewoods","title":"tildagon-bubble","releaseHash":"f154c5c2e3056b883c896072a56b32ffa4890547"},"releaseTime":"2024-06-02T19:54:27Z","tarballUrl":"https://codeload.github.com/merlininthewoods/tildagon-bubble/legacy.tar.gz/f154c5c2e3056b883c896072a56b32ffa4890547","manifest":{"app":{"name":"Bubble","category":"Apps"},"metadata":{"author":"Merlin Howse","license":"LGPL-3.0-only","url":"https://www.github.com/npentrel/tildagon-snake","description":"Simple spirit level aka bubble App","version":"1.0.0"}}},{"code":"40204021","id":{"service":"github","owner":"walkerdanny","title":"caffeine-jitters","releaseHash":"be3230741fc0cd33181f46e3dbc3c21d187161e0"},"releaseTime":"2024-06-20T22:17:39Z","tarballUrl":"https://codeload.github.com/walkerdanny/caffeine-jitters/legacy.tar.gz/be3230741fc0cd33181f46e3dbc3c21d187161e0","manifest":{"app":{"name":"Caffeine Jitters","category":"Apps"},"metadata":{"author":"walkerdanny","license":"MIT","url":"https://github.com/walkerdanny/caffeine-jitters","description":"Companion app for the Club Mate haptics hexpansion. Up and down buttons change the jitter frequency!","version":"0.0.3"}}},{"code":"01213303","id":{"service":"github","owner":"ashhhleyyy","title":"tildagon-cat","releaseHash":"dcf7cc823080d41805824d963291b231b9150ab6"},"releaseTime":"2024-06-01T22:46:19Z","tarballUrl":"https://codeload.github.com/ashhhleyyy/tildagon-cat/legacy.tar.gz/dcf7cc823080d41805824d963291b231b9150ab6","manifest":{"app":{"name":"Cat App","category":"Badge"},"metadata":{"author":"ashhhleyyy","license":"MPL-2.0","url":"https://github.com/ashhhleyyy/tildagon-cat","description":"a lil cat for your badge, you can even pet the cutie :3","version":"0.0.1"}}},{"code":"23003241","id":{"service":"github","owner":"tomsci","title":"tildagon-clock","releaseHash":"9dd787b01b88b495a5afb8d3993cc5b8277e958d"},"releaseTime":"2024-06-02T12:23:04Z","tarballUrl":"https://codeload.github.com/tomsci/tildagon-clock/legacy.tar.gz/9dd787b01b88b495a5afb8d3993cc5b8277e958d","manifest":{"app":{"name":"Clock","category":"Badge"},"metadata":{"author":"tomsci","license":"LGPL-3.0-only","url":"https://www.github.com/tomsci/tildagon-clock","description":"A Simple analogue clock","version":"0.2.0"}}},{"code":"02210134","id":{"service":"github","owner":"edent","title":"tildagon-clocky","releaseHash":"bc0119a27a7cd6e46e0551fb1078e726f0a173b8"},"releaseTime":"2024-06-12T07:06:19Z","tarballUrl":"https://codeload.github.com/edent/tildagon-clocky/legacy.tar.gz/bc0119a27a7cd6e46e0551fb1078e726f0a173b8","manifest":{"app":{"name":"Clocky","category":"Badge"},"metadata":{"author":"edent","license":"MIT","url":"https://github.com/edent/tildagon-clocky","description":"A clock / watch for your Tildagon. Hardcoded to BST.","version":"0.0.1"}}},{"code":"00102032","id":{"service":"github","owner":"Davermouse","title":"hexbadge","releaseHash":"69bd870cc9e8c60f2d89c732a235b218c3944816"},"releaseTime":"2024-06-02T08:51:15Z","tarballUrl":"https://codeload.github.com/Davermouse/hexbadge/legacy.tar.gz/69bd870cc9e8c60f2d89c732a235b218c3944816","manifest":{"app":{"name":"DM HexBadge","category":"Badge"},"metadata":{"author":"davermouse","license":"0BSD","url":"https://github.com/Davermouse/hexbadge","description":"A simple badge app with some spinning hexagons","version":"0.0.2"}}},{"code":"04231300","id":{"service":"github","owner":"andypiper","title":"emf-duckfacts-tildagon","releaseHash":"4825f06a2e7c86320b7794fbcf8af3bf8261d912"},"releaseTime":"2024-06-13T13:17:27Z","tarballUrl":"https://codeload.github.com/andypiper/emf-duckfacts-tildagon/legacy.tar.gz/4825f06a2e7c86320b7794fbcf8af3bf8261d912","manifest":{"app":{"name":"Duck Facts","category":"Apps"},"metadata":{"author":"andypiper","license":"MIT","url":"https://github.com/andypiper/emf-duckfacts-tildagon","description":"Important Duck Facts for your Tildagon","version":"0.0.1"}}},{"code":"14324030","id":{"service":"github","owner":"jimmu","title":"badge-a-sketch","releaseHash":"9d20e841d5bd1a18258184e025e9ad394be4ba3d"},"releaseTime":"2024-06-27T09:04:17Z","tarballUrl":"https://codeload.github.com/jimmu/badge-a-sketch/legacy.tar.gz/9d20e841d5bd1a18258184e025e9ad394be4ba3d","manifest":{"app":{"name":"Echt-A-Sketch","category":"Badge"},"metadata":{"author":"Jimmu","license":"MIT","url":"https://github.com/jimmu/badge-a-sketch/","description":"Frustrating drawing tool. Shake upside down to erase.","version":"0.1"}}},{"code":"13123304","id":{"service":"github","owner":"eehackspace","title":"tildagon-app-eehneopixellogo","releaseHash":"de94fef99ff90a84efeb79a6701aeaedc3849505"},"releaseTime":"2024-06-04T22:34:53Z","tarballUrl":"https://codeload.github.com/eehackspace/tildagon-app-eehneopixellogo/legacy.tar.gz/de94fef99ff90a84efeb79a6701aeaedc3849505","manifest":{"app":{"name":"EEH Logo","category":"Apps"},"metadata":{"author":"Matt Emerick-Law","license":"MIT","url":"https://github.com/eehackspace/tildagon-app-eehneopixellogo/","description":"App for controlling the NeoPixels on the EEH LED Logo Hexpansion. Come see us at EMF 2026 if you want to buy one of our hexpansions.","version":"0.2.1"}}},{"code":"12102212","id":{"service":"github","owner":"pikesley","title":"tildagon-countdown","releaseHash":"5738a3c93c8184b2e930b968af9803cb06111229"},"releaseTime":"2025-07-27T13:41:05Z","tarballUrl":"https://codeload.github.com/pikesley/tildagon-countdown/legacy.tar.gz/5738a3c93c8184b2e930b968af9803cb06111229","manifest":{"app":{"name":"EMF 2026 Countdown","category":"Badge"},"metadata":{"author":"pikesley","license":"MIT","url":"https://www.github.com/pikesley/tildagon-countdown","description":"Countdown to EMF 2026. Up and Down buttons to change the units.","version":"0.0.6"}}},{"code":"33043342","id":{"service":"github","owner":"pikesley","title":"tildagon-emf-cave","releaseHash":"688129d3b216a026fcfd5c6654211e80626827c8"},"releaseTime":"2025-02-08T11:45:46Z","tarballUrl":"https://codeload.github.com/pikesley/tildagon-emf-cave/legacy.tar.gz/688129d3b216a026fcfd5c6654211e80626827c8","manifest":{"app":{"name":"EMF Cave","category":"Games"},"metadata":{"author":"pikesley","license":"MIT","url":"https://www.github.com/pikesley/tildagon-emf-cave","description":"A reimplementation of an ancient Palm Pilot game, SFCave","version":"0.0.2"}}},{"code":"40233134","id":{"service":"github","owner":"martin-hamilton","title":"EMF-Day","releaseHash":"bbaa5c8f59af8fe14d27455bcf41ea39d3c1fc65"},"releaseTime":"2024-06-13T15:54:12Z","tarballUrl":"https://codeload.github.com/martin-hamilton/EMF-Day/legacy.tar.gz/bbaa5c8f59af8fe14d27455bcf41ea39d3c1fc65","manifest":{"app":{"name":"EMF_Day","category":"Badge"},"metadata":{"author":"MartinH","license":"LGPL-3.0-only","url":"https://github.com/martin-hamilton/EMF-DAY","description":"EMF never ended. Find out what day of the festival it is today.","version":"0.0.1"}}},{"code":"41003012","id":{"service":"github","owner":"martin-hamilton","title":"EMF-Spinner","releaseHash":"09a0aae29b4ec29fdf259585361a29b43fbabe95"},"releaseTime":"2024-06-20T22:33:16Z","tarballUrl":"https://codeload.github.com/martin-hamilton/EMF-Spinner/legacy.tar.gz/09a0aae29b4ec29fdf259585361a29b43fbabe95","manifest":{"app":{"name":"EMF_Spinner","category":"Badge"},"metadata":{"author":"MartinH","license":"LGPL-3.0-only","url":"https://github.com/martin-hamilton/EMF-Spinner","description":"Spinny EMF 2024 logo with trippy background colours","version":"0.0.1"}}},{"code":"12403030","id":{"service":"github","owner":"mbooth101","title":"emf-eyapp","releaseHash":"4018010f32c7a2a6f26a2d3073286d61cbdf68d7"},"releaseTime":"2024-06-16T18:31:45Z","tarballUrl":"https://codeload.github.com/mbooth101/emf-eyapp/legacy.tar.gz/4018010f32c7a2a6f26a2d3073286d61cbdf68d7","manifest":{"app":{"name":"Ey App","category":"Apps"},"metadata":{"author":"mbooth","license":"MIT","url":"https://github.com/mbooth101/emf-eyapp","description":"A northerner simulator.","version":"8"}}},{"code":"14434241","id":{"service":"github","owner":"FerNerd","title":"tildagon-ferdi-app","releaseHash":"36cf5e5e0ada3d8f202044529573428ebff501b9"},"releaseTime":"2024-06-01T23:16:37Z","tarballUrl":"https://codeload.github.com/FerNerd/tildagon-ferdi-app/legacy.tar.gz/36cf5e5e0ada3d8f202044529573428ebff501b9","manifest":{"app":{"name":"Ferdi App","category":"Badge"},"metadata":{"author":"ferdinandsmit","license":"LGPL-3.0-only","url":"https://github.com/Smitplaza/tildagon-ferdi-app","description":"My Cool Tildagon App","version":"0.0.11"}}},{"code":"22023130","id":{"service":"github","owner":"AndreasThinks","title":"tildagon-flappy-boy","releaseHash":"0fba1c174c1d6a541d3200b3a8098442f3477f4a"},"releaseTime":"2024-05-31T13:53:38Z","tarballUrl":"https://codeload.github.com/AndreasThinks/tildagon-flappy-boy/legacy.tar.gz/0fba1c174c1d6a541d3200b3a8098442f3477f4a","manifest":{"app":{"name":"Flappy Boy","category":"Games"},"metadata":{"author":"AndreasThinks","license":"LGPL-3.0-only","url":"https://github.com/AndreasThinks/tildagon-flappy-boy","description":"A Flappy Bird style game","version":"0.0.1"}}},{"code":"13113413","id":{"service":"github","owner":"chaos-dotcom","title":"fluroclockapp","releaseHash":"3462c88f905aac219bc8f9dd4f9a1cbebdb2b587"},"releaseTime":"2024-06-13T23:40:38Z","tarballUrl":"https://codeload.github.com/chaos-dotcom/fluroclockapp/legacy.tar.gz/3462c88f905aac219bc8f9dd4f9a1cbebdb2b587","manifest":{"app":{"name":"Fluroclock","category":"Media"},"metadata":{"author":"John Rogers & Ben Eriksson","license":"MIT","url":"https://github.com/Johnr24/fluroclockapp","description":"Control the Fluroclock at EMF, from your badge!","version":"0.0.5"}}},{"code":"33241012","id":{"service":"github","owner":"Kimbsy","title":"tildagon-life","releaseHash":"1abf63139919532966b818bc82b578ba922f3da6"},"releaseTime":"2024-06-01T18:33:06Z","tarballUrl":"https://codeload.github.com/Kimbsy/tildagon-life/legacy.tar.gz/1abf63139919532966b818bc82b578ba922f3da6","manifest":{"app":{"name":"Game of Life","category":"Games"},"metadata":{"author":"Kimbsy","license":"LGPL-3.0-only","url":"https://github.com/Kimbsy/tildagon-life","description":"Simulate Life exactly as Conway imagined it","version":"0.0.7"}}},{"code":"12442102","id":{"service":"github","owner":"gchq-net","title":"badge-app","releaseHash":"b9834f3d7b3d79f4c6a0410f0f0292361269948a"},"releaseTime":"2024-05-31T16:09:19Z","tarballUrl":"https://codeload.github.com/gchq-net/badge-app/legacy.tar.gz/b9834f3d7b3d79f4c6a0410f0f0292361269948a","manifest":{"app":{"name":"GCHQ.NET","category":"Badge"},"metadata":{"author":"GCHQ.NET","license":"LGPL-3.0-only","url":"https://github.com/gchq-net/badge-app","description":"GCHQ Badge companion app","version":"0.4.1"}}},{"code":"32412034","id":{"service":"github","owner":"usedbytes","title":"tildagon-ballcage","releaseHash":"b5c10cada11ce96189e53cba668506f2b16ab469"},"releaseTime":"2024-06-02T10:58:28Z","tarballUrl":"https://codeload.github.com/usedbytes/tildagon-ballcage/legacy.tar.gz/b5c10cada11ce96189e53cba668506f2b16ab469","manifest":{"app":{"name":"Googly","category":"Badge"},"metadata":{"author":"usedbytes","license":"LGPL-3.0-only","url":"https://github.com/usedbytes/tildagon-ballcage","description":"A Googly Eye. Everyone loves Googly Eyes. The physics is a bit jank.","version":"0.0.4"}}},{"code":"44023001","id":{"service":"github","owner":"AgentAntelope","title":"grayme_badge","releaseHash":"b552e0a2dcf49a23b5dc4f6efd49c1f0b730ff22"},"releaseTime":"2024-06-05T08:53:03Z","tarballUrl":"https://codeload.github.com/AgentAntelope/grayme_badge/legacy.tar.gz/b552e0a2dcf49a23b5dc4f6efd49c1f0b730ff22","manifest":{"app":{"name":"GraymeBadge","category":"Badge"},"metadata":{"author":"AgentAntelope","license":"Unlicense","url":"https://github.com/AgentAntelope/grayme_badge/","description":"A greyscale 'Hello my name is' sticker style Tildagon name badge. Rendering based on jake-walker's","version":"0.0.3"}}},{"code":"22234044","id":{"service":"github","owner":"ChrisDick","title":"Tildagon-Pattern-Example","releaseHash":"ccb75aa3e0a5c03548eb503eedb0864f026d47d7"},"releaseTime":"2025-08-31T17:17:45Z","tarballUrl":"https://codeload.github.com/ChrisDick/Tildagon-Pattern-Example/legacy.tar.gz/ccb75aa3e0a5c03548eb503eedb0864f026d47d7","manifest":{"app":{"name":"green flash","category":"Pattern"},"metadata":{"author":"Chris Dick","license":"MIT","url":"https://github.com/chrisdick/tildagon-pattern-green-flash/","description":"green version of the built in flash pattern for testing led sequence feature","version":"0.0.1"}}},{"code":"43301002","id":{"service":"github","owner":"ThomasJackDalby","title":"tildagon-flashy","releaseHash":"6953d232144f3c65c1e0e4d1bb6cb6a3e911c8ee"},"releaseTime":"2024-06-02T15:40:45Z","tarballUrl":"https://codeload.github.com/ThomasJackDalby/tildagon-flashy/legacy.tar.gz/6953d232144f3c65c1e0e4d1bb6cb6a3e911c8ee","manifest":{"app":{"name":"HAB Flash","category":"Badge"},"metadata":{"author":"Tom Dalby","license":"MIT","url":"https://github.com/ThomasJackDalby/tildagon-flashy","description":"The essential navigation (and tracking) tool for EMF 2024. Allows the wearer to beam their current location to HABVille, through the medium of receipt printing. (to be clear, this will actually print a physical receipt of your location at HABVille (during EMF 2024)).","version":"0.0.4"}}},{"code":"10421022","id":{"service":"github","owner":"samtygier","title":"tildagon-hacktheplanet","releaseHash":"4d6324e4ff44339ef1b3d0f69d73c6f77fc6e3b4"},"releaseTime":"2024-06-02T16:16:14Z","tarballUrl":"https://codeload.github.com/samtygier/tildagon-hacktheplanet/legacy.tar.gz/4d6324e4ff44339ef1b3d0f69d73c6f77fc6e3b4","manifest":{"app":{"name":"Hack the Planet","category":"Badge"},"metadata":{"author":"Sam Tygier","license":"LGPL-3.0-only","url":"https://www.github.com/samtygier/tildagon-hacktheplanet","description":"Hack the Planet","version":"0.0.6"}}},{"code":"00024330","id":{"service":"github","owner":"jake-walker","title":"tildagon-name-badge","releaseHash":"07aca4cbac964de37b77941668e3ead2807955ca"},"releaseTime":"2024-05-31T18:39:32Z","tarballUrl":"https://codeload.github.com/jake-walker/tildagon-name-badge/legacy.tar.gz/07aca4cbac964de37b77941668e3ead2807955ca","manifest":{"app":{"name":"Hello Name Badge","category":"Badge"},"metadata":{"author":"jake-walker","license":"Unlicense","url":"https://github.com/jake-walker/tildagon-name-badge","description":"A simple 'Hello my name is' sticker style Tildagon name badge","version":"0.0.3"}}},{"code":"13322421","id":{"service":"github","owner":"emfcamp","title":"badge-2024-apps-hexfile","releaseHash":"e8b783349eda65e582b4fcaf44204a072551157a"},"releaseTime":"2025-03-03T22:52:49Z","tarballUrl":"https://codeload.github.com/emfcamp/badge-2024-apps-hexfile/legacy.tar.gz/e8b783349eda65e582b4fcaf44204a072551157a","manifest":{"app":{"name":"Hexfile","category":"Badge"},"metadata":{"author":"ChrisDick","license":"MIT","url":"https://www.github.com/emfcamp/badge-2024-apps-hexfile","description":"File explorer with Cut, Copy, Paste, Delete, Rename and mkdir. Can copy files and folders up to 3 levels deep onto any mounted storage.","version":"1.0.0"}}},{"code":"23423332","id":{"service":"github","owner":"DolicaAkelloEgwel","title":"ikeda-type-beat","releaseHash":"b7fc8a414a146596ec5da628bc218d4d11e9bdde"},"releaseTime":"2024-06-25T14:15:18Z","tarballUrl":"https://codeload.github.com/DolicaAkelloEgwel/ikeda-type-beat/legacy.tar.gz/b7fc8a414a146596ec5da628bc218d4d11e9bdde","manifest":{"app":{"name":"Ikeda Type Beat","category":"Badge"},"metadata":{"author":"DolicaAkelloEgwel","license":"LGPL-3.0-only","url":"https://github.com/DolicaAkelloEgwel/ikeda-type-beat","description":"Some visuals inspired by Ryoji Ikeda. Use the A and D buttons to switch between different modes.","version":"0.0.4"}}},{"code":"40114332","id":{"service":"github","owner":"npentrel","title":"imu-readings","releaseHash":"95145317228ecdf2de6d3f1c332d170a7625e79d"},"releaseTime":"2024-06-02T10:45:51Z","tarballUrl":"https://codeload.github.com/npentrel/imu-readings/legacy.tar.gz/95145317228ecdf2de6d3f1c332d170a7625e79d","manifest":{"app":{"name":"IMU Readings","category":"Games"},"metadata":{"author":"naomi","license":"LGPL-3.0-only","url":"https://www.github.com/npentrel/imu-readings","description":"See the readings of the IMU as you move the badge.","version":"1.0.0"}}},{"code":"14434141","id":{"service":"github","owner":"LGDan","title":"Tildagon_IP_App","releaseHash":"0b9c50197c04533a43566d23c2f7e1a787c3ebb5"},"releaseTime":"2024-05-31T16:46:04Z","tarballUrl":"https://codeload.github.com/LGDan/Tildagon_IP_App/legacy.tar.gz/0b9c50197c04533a43566d23c2f7e1a787c3ebb5","manifest":{"app":{"name":"IP Address","category":"Badge"},"metadata":{"author":"LGDan","license":"LGPL-3.0-only","url":"https://github.com/LGDan/Tildagon_IP_App","description":"EMF 2024 App to get the IP of your badge.","version":"0.0.1"}}},{"code":"22302110","id":{"service":"github","owner":"pixelscript","title":"clock.json","releaseHash":"58f2f524e6636553d6f26cbdfb4cce4240b1e0a6"},"releaseTime":"2024-06-02T16:04:32Z","tarballUrl":"https://codeload.github.com/pixelscript/clock.json/legacy.tar.gz/58f2f524e6636553d6f26cbdfb4cce4240b1e0a6","manifest":{"app":{"name":"json clock","category":"Badge"},"metadata":{"author":"pixelscript","license":"Apache-2.0","url":"https://www.github.com/pixelscript/clock.json","description":"A JSON style clock that uses your ip to work out local time.","version":"0.0.7"}}},{"code":"13044240","id":{"service":"github","owner":"DolicaAkelloEgwel","title":"magic-8-ball","releaseHash":"291b74159030ab045813ef5915a071e9965d3de3"},"releaseTime":"2024-06-27T13:09:46Z","tarballUrl":"https://codeload.github.com/DolicaAkelloEgwel/magic-8-ball/legacy.tar.gz/291b74159030ab045813ef5915a071e9965d3de3","manifest":{"app":{"name":"Magic 8 Ball","category":"Badge"},"metadata":{"author":"DolicaAkelloEgwel","license":"LGPL-3.0-only","url":"https://github.com/DolicaAkelloEgwel/magic-8-ball","description":"Shake the Magic 8 Ball to learn your fate.","version":"0.0.1"}}},{"code":"11303314","id":{"service":"github","owner":"andreacampanella","title":"tildagon-Martrix","releaseHash":"50b2552da9599723da29f9c1209adddb34528cc2"},"releaseTime":"2024-06-01T11:17:54Z","tarballUrl":"https://codeload.github.com/andreacampanella/tildagon-Martrix/legacy.tar.gz/50b2552da9599723da29f9c1209adddb34528cc2","manifest":{"app":{"name":"Matrix rain","category":"Apps"},"metadata":{"author":"emuboy","license":"LGPL-3.0-only","url":"https://github.com/andreacampanella/tildagon-Martrix","description":"Enter the Matrix","version":"0.0.1"}}},{"code":"20120243","id":{"service":"github","owner":"MatthewWilkes","title":"md-updater","releaseHash":"d14b0259e9e07f3384c0b8f978d6a48d80bd65f0"},"releaseTime":"2025-08-24T16:58:10Z","tarballUrl":"https://codeload.github.com/MatthewWilkes/md-updater/legacy.tar.gz/d14b0259e9e07f3384c0b8f978d6a48d80bd65f0","manifest":{"app":{"name":"MD Updater","category":"Badge"},"metadata":{"author":"Matthew Wilkes","license":"LGPL-3.0-only","url":"https://www.github.com/username/repo","description":"A utility to update the firmware of the Megadrive interface hexpansion","version":"2.0.1"}}},{"code":"42143024","id":{"service":"github","owner":"pikesley","title":"tildagon-miner","releaseHash":"361c869d6c350a6d052f3217fa88fd132c43ad76"},"releaseTime":"2025-02-16T16:16:07Z","tarballUrl":"https://codeload.github.com/pikesley/tildagon-miner/legacy.tar.gz/361c869d6c350a6d052f3217fa88fd132c43ad76","manifest":{"app":{"name":"Miner","category":"Games"},"metadata":{"author":"pikesley","license":"MIT","url":"https://www.github.com/tildagon-miner","description":"Miner Willy wandering around your Tildagon","version":"0.0.1"}}},{"code":"13301203","id":{"service":"github","owner":"estuans","title":"tildagon-multiclock","releaseHash":"b79cd1b43e4476323102a695df1181c7e9865378"},"releaseTime":"2024-06-14T13:44:29Z","tarballUrl":"https://codeload.github.com/estuans/tildagon-multiclock/legacy.tar.gz/b79cd1b43e4476323102a695df1181c7e9865378","manifest":{"app":{"name":"MultiClock","category":"Badge"},"metadata":{"author":"estuans","license":"LGPL-3.0-only","url":"https://www.github.com/estuans/tildagon-multiclock","description":"A Clock with support for multiple faces","version":"0.2.3"}}},{"code":"14402304","id":{"service":"github","owner":"Cheukting","title":"tildagon-mystify","releaseHash":"847bb4fa455efe06e12ba8abca8022e6826435fa"},"releaseTime":"2024-06-04T17:03:33Z","tarballUrl":"https://codeload.github.com/Cheukting/tildagon-mystify/legacy.tar.gz/847bb4fa455efe06e12ba8abca8022e6826435fa","manifest":{"app":{"name":"Mystify","category":"Media"},"metadata":{"author":"Cheukting","license":"LGPL-3.0-only","url":"https://github.com/Cheukting/tildagon-mystify","description":"Recreation of the classic Window 3.1 screensaver Mystify.","version":"0.1.0"}}},{"code":"32310121","id":{"service":"github","owner":"AaronJackson","title":"tildagon-nottinghack-logo","releaseHash":"25297213e87033991f0a7a2f34c35c7f38e1df34"},"releaseTime":"2024-06-05T22:47:44Z","tarballUrl":"https://codeload.github.com/AaronJackson/tildagon-nottinghack-logo/legacy.tar.gz/25297213e87033991f0a7a2f34c35c7f38e1df34","manifest":{"app":{"name":"NottingHack Logo","category":"Badge"},"metadata":{"author":"aaronjackson","license":"LGPL-3.0-only","url":"https://www.github.com/aaronjackson/tildagon-nottinghack-logo","description":"Shows nottinghack logo","version":"0.0.1"}}},{"code":"32031122","id":{"service":"github","owner":"emericklaw","title":"tildagon-app-pacman-led","releaseHash":"6b44e7a317e84ace5ccb2178b4cfe05cce11aced"},"releaseTime":"2024-06-27T10:26:03Z","tarballUrl":"https://codeload.github.com/emericklaw/tildagon-app-pacman-led/legacy.tar.gz/6b44e7a317e84ace5ccb2178b4cfe05cce11aced","manifest":{"app":{"name":"Pacman LED","category":"Apps"},"metadata":{"author":"Matt Emerick-Law","license":"MIT","url":"https://github.com/emericklaw/tildagon-app-pacman-led/","description":"Control the LEDs on the Pacman hexpansion created by The Untitled Goose.","version":"0.1.0"}}},{"code":"21002344","id":{"service":"github","owner":"pikesley","title":"tildagon-particle-man","releaseHash":"8ff2ea9063163fcd29730b4d14fa1dde92b27061"},"releaseTime":"2025-02-28T14:54:23Z","tarballUrl":"https://codeload.github.com/pikesley/tildagon-particle-man/legacy.tar.gz/8ff2ea9063163fcd29730b4d14fa1dde92b27061","manifest":{"app":{"name":"Particle Man","category":"Games"},"metadata":{"author":"pikesley","license":"MIT","url":"https://www.github.com/pikesley/tildagon-particle-man","description":"Elastically-colliding particles","version":"0.0.2"}}},{"code":"13133010","id":{"service":"github","owner":"oholiab","title":"tildagon-pentagram-app","releaseHash":"509c876427e92a70be71fdbe2f44dea0275eaad0"},"releaseTime":"2024-06-02T16:12:09Z","tarballUrl":"https://codeload.github.com/oholiab/tildagon-pentagram-app/legacy.tar.gz/509c876427e92a70be71fdbe2f44dea0275eaad0","manifest":{"app":{"name":"Pentagram","category":"Badge"},"metadata":{"author":"grimmware","license":"WTFPL","url":"https://github.com/oholiab/tildagon-pentagram-app","description":"EMF 2024 App to invoke dark powers.","version":"0.0.3"}}},{"code":"41141121","id":{"service":"github","owner":"ProtonNumber","title":"PrideCircles","releaseHash":"1dcc05ed6ebdf6e696d158dc250ec2da61ba80a0"},"releaseTime":"2024-06-02T17:51:06Z","tarballUrl":"https://codeload.github.com/ProtonNumber/PrideCircles/legacy.tar.gz/1dcc05ed6ebdf6e696d158dc250ec2da61ba80a0","manifest":{"app":{"name":"PrideCircles","category":"Badge"},"metadata":{"author":"Claire","license":"LGPL-3.0-only","url":"https://github.com/ProtonNumber/PrideCircles","description":"A simple pride flag visualiser, but circles! Use the B / E buttons to cycle through flags, use A / D to control brightness. Now with LEDs!","version":"0.2.0"}}},{"code":"23203304","id":{"service":"github","owner":"RichardoC","title":"richard-name-badge","releaseHash":"7e0501f73479ebe3c5bef8cf6602162838f5d317"},"releaseTime":"2024-06-01T12:52:11Z","tarballUrl":"https://codeload.github.com/RichardoC/richard-name-badge/legacy.tar.gz/7e0501f73479ebe3c5bef8cf6602162838f5d317","manifest":{"app":{"name":"Richard name badge","category":"Badge"},"metadata":{"author":"richardoc","license":"MIT","url":"https://github.com/RichardoC/richard-name-badge","description":" A badge if your name is Richard!","version":"0.0.1"}}},{"code":"00324211","id":{"service":"github","owner":"thomasmichaelwallace","title":"LeoSuit","releaseHash":"e4833378821df3952fcb8a9e494be6db74f7e50e"},"releaseTime":"2024-06-01T21:51:17Z","tarballUrl":"https://codeload.github.com/thomasmichaelwallace/LeoSuit/legacy.tar.gz/e4833378821df3952fcb8a9e494be6db74f7e50e","manifest":{"app":{"name":"roygbiVW","category":"Apps"},"metadata":{"author":"thomasmichaelwallace","license":"MIT","url":"https://github.com/thomasmichaelwallace/leos-suit","description":"Control the roygbiVW LED van!","version":"0.0.6"}}},{"code":"01443142","id":{"service":"github","owner":"pikesley","title":"tildagon-bounce","releaseHash":"e80fe8b9a34022d237f83f084112b002fcb22951"},"releaseTime":"2025-02-07T22:28:55Z","tarballUrl":"https://codeload.github.com/pikesley/tildagon-bounce/legacy.tar.gz/e80fe8b9a34022d237f83f084112b002fcb22951","manifest":{"app":{"name":"Sam's Bouncing Blobs","category":"Games"},"metadata":{"author":"pikesley","license":"MIT","url":"https://www.github.com/pikesley/tildagon-bounce","description":"Some bouncing blobs on your TIldagon. See the README for what the buttons do","version":"0.0.1"}}},{"code":"32001300","id":{"service":"github","owner":"pikesley","title":"tildagon-clock","releaseHash":"0783ecd4022af8839e8e14343fe6801914cc869b"},"releaseTime":"2025-02-07T22:16:54Z","tarballUrl":"https://codeload.github.com/pikesley/tildagon-clock/legacy.tar.gz/0783ecd4022af8839e8e14343fe6801914cc869b","manifest":{"app":{"name":"Sam's Clock","category":"Games"},"metadata":{"author":"pikesley","license":"MIT","url":"https://www.github.com/pikesley/tildagon-clock","description":"Tell time on the Tildagon. See the README for what the buttons do","version":"0.0.8"}}},{"code":"13220401","id":{"service":"github","owner":"pikesley","title":"tildagon-simon","releaseHash":"657b21884c6792d4b7f9cfcfcabcc282b274d9d0"},"releaseTime":"2025-02-16T16:24:22Z","tarballUrl":"https://codeload.github.com/pikesley/tildagon-simon/legacy.tar.gz/657b21884c6792d4b7f9cfcfcabcc282b274d9d0","manifest":{"app":{"name":"Simon","category":"Games"},"metadata":{"author":"pikesley","license":"MIT","url":"https://www.github.com/pikesley/tildagon-simon","description":"A reimplementation of an ancient game. Shake the badge to start or move to the next round","version":"0.0.3"}}},{"code":"20434242","id":{"service":"github","owner":"npentrel","title":"tildagon-snake","releaseHash":"c55f3c4cc7ecbc13f28c6965837b8d5a8e54e9ba"},"releaseTime":"2024-06-01T14:52:50Z","tarballUrl":"https://codeload.github.com/npentrel/tildagon-snake/legacy.tar.gz/c55f3c4cc7ecbc13f28c6965837b8d5a8e54e9ba","manifest":{"app":{"name":"Snake","category":"Games"},"metadata":{"author":"naomi","license":"LGPL-3.0-only","url":"https://www.github.com/npentrel/tildagon-snake","description":"Play snake on your tildagon badge.","version":"1.0.0"}}},{"code":"33101100","id":{"service":"github","owner":"npentrel","title":"tildagon-snake-imu","releaseHash":"93b164d642292df170f0d995fd3ef8c86c37cb0d"},"releaseTime":"2024-06-01T14:54:01Z","tarballUrl":"https://codeload.github.com/npentrel/tildagon-snake-imu/legacy.tar.gz/93b164d642292df170f0d995fd3ef8c86c37cb0d","manifest":{"app":{"name":"SnakeIMU","category":"Games"},"metadata":{"author":"naomi","license":"LGPL-3.0-only","url":"https://www.github.com/npentrel/tildagon-snake-imu","description":"Play snake by tilting your tildagon badge. Press CONFIRM to start.","version":"1.0.1"}}},{"code":"01232312","id":{"service":"github","owner":"pikesley","title":"tildagon-space-invaders","releaseHash":"b6df95f2ca8463f8c16db151013491c5a277aa9e"},"releaseTime":"2025-02-16T16:07:37Z","tarballUrl":"https://codeload.github.com/pikesley/tildagon-space-invaders/legacy.tar.gz/b6df95f2ca8463f8c16db151013491c5a277aa9e","manifest":{"app":{"name":"SpaceInvaders","category":"Games"},"metadata":{"author":"pikesley","license":"MIT","url":"https://www.github.com/pikesley/tildagon-space-invaders","description":"Some Space Invaders on your Tildagon","version":"0.0.1"}}},{"code":"30001104","id":{"service":"github","owner":"MikeS159","title":"tildagon-speedtest","releaseHash":"d2803f7d111b281427d545654ee9f4de6ca384c6"},"releaseTime":"2024-06-02T10:35:42Z","tarballUrl":"https://codeload.github.com/MikeS159/tildagon-speedtest/legacy.tar.gz/d2803f7d111b281427d545654ee9f4de6ca384c6","manifest":{"app":{"name":"Speed Test","category":"Apps"},"metadata":{"author":"MikeS159","license":"MIT","url":"https://github.com/MikeS159/tildagon-speedtest","description":"A simple speed test app, downloads for 5s then displays the speed","version":"0.1.2"}}},{"code":"22113333","id":{"service":"github","owner":"pixelscript","title":"spinning-cube","releaseHash":"f10143a965a9398527fd7eb18bb1446d046ab573"},"releaseTime":"2024-06-01T14:19:20Z","tarballUrl":"https://codeload.github.com/pixelscript/spinning-cube/legacy.tar.gz/f10143a965a9398527fd7eb18bb1446d046ab573","manifest":{"app":{"name":"Spinning Cube","category":"Badge"},"metadata":{"author":"pixelscript","license":"Apache-2.0","url":"https://www.github.com/pixelscript/spinning-cube","description":"Literally just a spinning cube. Press buttons to change colours, rotation and trails","version":"0.0.3"}}},{"code":"41223220","id":{"service":"github","owner":"saukothari","title":"tildagon-spymato","releaseHash":"7e3207d902553f2b8a7b43de6cdd7c3b8c4a41ee"},"releaseTime":"2024-06-05T09:33:51Z","tarballUrl":"https://codeload.github.com/saukothari/tildagon-spymato/legacy.tar.gz/7e3207d902553f2b8a7b43de6cdd7c3b8c4a41ee","manifest":{"app":{"name":"SPYMATO","category":"Badge"},"metadata":{"author":"saukothari","license":"LGPL-3.0-only","url":"https://github.com/saukothari/tildagon-spymato","description":"Red tomato with animated eyes.","version":"0.0.1"}}},{"code":"21404312","id":{"service":"github","owner":"pixelscript","title":"starfield","releaseHash":"4f801c0ebd1e4cf2408f7500a71febf81c986da7"},"releaseTime":"2024-06-01T14:10:54Z","tarballUrl":"https://codeload.github.com/pixelscript/starfield/legacy.tar.gz/4f801c0ebd1e4cf2408f7500a71febf81c986da7","manifest":{"app":{"name":"Starfield","category":"Badge"},"metadata":{"author":"pixelscript","license":"Apache-2.0","url":"https://www.github.com/pixelscript/starfield","description":"A simulation of a starfield press right for colours","version":"0.0.3"}}},{"code":"23222210","id":{"service":"github","owner":"rbirkby","title":"TildagonTetris","releaseHash":"20ece7b375cb960304d42bbb091afe5d420edc63"},"releaseTime":"2024-05-31T17:24:25Z","tarballUrl":"https://codeload.github.com/rbirkby/TildagonTetris/legacy.tar.gz/20ece7b375cb960304d42bbb091afe5d420edc63","manifest":{"app":{"name":"Tetris","category":"Games"},"metadata":{"author":"rbirkby","license":"MIT","url":"https://www.github.com/rbirkby/TildagonTetris","description":"Play Tetris on your Tildagon! 🟥🟥🟥🟥","version":"0.0.4"}}},{"code":"22243400","id":{"service":"github","owner":"ntflix","title":"Tildagon-Bitmap-Demo","releaseHash":"8825cf7537fdc7d9b3aa26074b532c7a42dd89bc"},"releaseTime":"2024-06-02T22:04:26Z","tarballUrl":"https://codeload.github.com/ntflix/Tildagon-Bitmap-Demo/legacy.tar.gz/8825cf7537fdc7d9b3aa26074b532c7a42dd89bc","manifest":{"app":{"name":"TildaGonCrazy","category":"Badge"},"metadata":{"author":"felixweber","license":"LGPL-3.0-only","url":"https://github.com/ntflix/Tildagon-Bitmap-Demo","description":"Party LEDs! Press different buttons to find out.","version":"0.1"}}},{"code":"22331330","id":{"service":"github","owner":"ChrisDick","title":"tildagone","releaseHash":"6de87f05ff2d71c48c2c0a3f01c9e04916f8024f"},"releaseTime":"2025-06-10T21:57:05Z","tarballUrl":"https://codeload.github.com/ChrisDick/tildagone/legacy.tar.gz/6de87f05ff2d71c48c2c0a3f01c9e04916f8024f","manifest":{"app":{"name":"TildaGone","category":"Background"},"metadata":{"author":"ChrisDick","license":"MIT","url":"https://www.github.com/ChrisDick/tildagone","description":"Test background app.","version":"1.0.3"}}},{"code":"11330220","id":{"service":"github","owner":"ntflix","title":"Tildagon-Torch","releaseHash":"16fbdd804784b17dc321ec72412ab5b272a8b4e1"},"releaseTime":"2024-06-07T11:45:21Z","tarballUrl":"https://codeload.github.com/ntflix/Tildagon-Torch/legacy.tar.gz/16fbdd804784b17dc321ec72412ab5b272a8b4e1","manifest":{"app":{"name":"Torch","category":"Badge"},"metadata":{"author":"felixweber","license":"LGPL-3.0-only","url":"https://github.com/ntflix/Tildagon-Torch","description":"A torch! Press B to turn on and off.","version":"1.1"}}},{"code":"24302400","id":{"service":"github","owner":"jiphex","title":"tildagon-torch","releaseHash":"7fcf4ff429209fae7912eac649c3d353dd38bb19"},"releaseTime":"2024-06-01T14:18:07Z","tarballUrl":"https://codeload.github.com/jiphex/tildagon-torch/legacy.tar.gz/7fcf4ff429209fae7912eac649c3d353dd38bb19","manifest":{"app":{"name":"Torchj","category":"Badge"},"metadata":{"author":"jiphex","license":"MIT","url":"https://www.github.com/jiphex/tildagon-torch","description":"A simple torch, lasts 3-4 hours","version":"0.0.4"}}},{"code":"40433243","id":{"service":"github","owner":"RichardoC","title":"wifi-switcher","releaseHash":"d662e961f52ccb161837d8a42c6b6901cc27ab38"},"releaseTime":"2024-09-12T21:26:33Z","tarballUrl":"https://codeload.github.com/RichardoC/wifi-switcher/legacy.tar.gz/d662e961f52ccb161837d8a42c6b6901cc27ab38","manifest":{"app":{"name":"Wifi Switcher","category":"Apps"},"metadata":{"author":"RichardoC","license":"MIT","url":"https://www.github.com/RichardoC_wifi_switcher","description":"Switch between multiple Wifi networks","version":"1.0.1"}}},{"code":"02041000","id":{"service":"github","owner":"usedbytes","title":"tildagon-wormhole","releaseHash":"42df5eba30f331978ac3eb825a7e6c9b320a3879"},"releaseTime":"2024-06-02T10:55:19Z","tarballUrl":"https://codeload.github.com/usedbytes/tildagon-wormhole/legacy.tar.gz/42df5eba30f331978ac3eb825a7e6c9b320a3879","manifest":{"app":{"name":"Wormhole","category":"Media"},"metadata":{"author":"usedbytes","license":"LGPL-3.0-only","url":"https://github.com/usedbytes/tildagon-wormhole","description":"A wormhole effect which renders too slowly","version":"0.0.3"}}}],"count":78}
+{
+  "items": [
+    {
+      "code": "30241313",
+      "id": {
+        "service": "github",
+        "owner": "jorants",
+        "title": "tildagon-acapp",
+        "releaseHash": "48582fe81f224127ac8471a51e13317fd37d98d0"
+      },
+      "releaseTime": "2024-06-01T22:27:09Z",
+      "tarballUrl": "https://codeload.github.com/jorants/tildagon-acapp/legacy.tar.gz/48582fe81f224127ac8471a51e13317fd37d98d0",
+      "manifest": {
+        "app": {
+          "name": "ACAB",
+          "category": "Badge"
+        },
+        "metadata": {
+          "author": "Control-K & Bublebee",
+          "license": "LGPL-3.0-only",
+          "url": "https://github.com/controlkNL/tildagon-acapp",
+          "description": "Some flags and LED colors as images to customize your badge",
+          "version": "0.0.3"
+        }
+      }
+    },
+    {
+      "code": "04112301",
+      "id": {
+        "service": "github",
+        "owner": "proffalken",
+        "title": "tildagon-basic-api-demo",
+        "releaseHash": "a8c82af3573c656c108b8deba1d3ff00822cf3a2"
+      },
+      "releaseTime": "2024-06-01T11:33:25Z",
+      "tarballUrl": "https://codeload.github.com/proffalken/tildagon-basic-api-demo/legacy.tar.gz/a8c82af3573c656c108b8deba1d3ff00822cf3a2",
+      "manifest": {
+        "app": {
+          "name": "API Demo",
+          "category": "Badge"
+        },
+        "metadata": {
+          "author": "proffalken",
+          "license": "MIT",
+          "url": "https://github.com/proffalken/tildagon-basic-api-demo",
+          "description": "A demo tildagon app for showing how to explore an api",
+          "version": "0.0.2"
+        }
+      }
+    },
+    {
+      "code": "01002340",
+      "id": {
+        "service": "github",
+        "owner": "mich181189",
+        "title": "Tildagon-ArtNet",
+        "releaseHash": "71e07f95efe7e5544246917b90394524e54b776d"
+      },
+      "releaseTime": "2024-07-07T10:29:40Z",
+      "tarballUrl": "https://codeload.github.com/mich181189/Tildagon-ArtNet/legacy.tar.gz/71e07f95efe7e5544246917b90394524e54b776d",
+      "manifest": {
+        "app": {
+          "name": "ArtNet Receiver",
+          "category": "Badge"
+        },
+        "metadata": {
+          "author": "mich181189",
+          "license": "BSD-3-Clause",
+          "url": "https://github.com/mich181189/Tildagon-ArtNet",
+          "description": "An ArtNet receiver for your badge! Currently a little janky and hard-coded",
+          "version": "0.0.1"
+        }
+      }
+    },
+    {
+      "code": "04431332",
+      "id": {
+        "service": "github",
+        "owner": "sodoku",
+        "title": "tildagon-avatar",
+        "releaseHash": "e06c65bbfa8302c0a89995a9d5921a3bfee44617"
+      },
+      "releaseTime": "2025-09-12T16:22:21Z",
+      "tarballUrl": "https://codeload.github.com/sodoku/tildagon-avatar/legacy.tar.gz/e06c65bbfa8302c0a89995a9d5921a3bfee44617",
+      "manifest": {
+        "app": {
+          "name": "Avatar",
+          "category": "Badge"
+        },
+        "metadata": {
+          "author": "sodoku",
+          "license": "LGPL-3.0-only",
+          "url": "https://www.github.com/sodoku/tildagon-avatar",
+          "description": "Display your github avatar",
+          "version": "0.0.2"
+        }
+      }
+    },
+    {
+      "code": "41334243",
+      "id": {
+        "service": "github",
+        "owner": "TeamRobotmad",
+        "title": "BadgeBot",
+        "releaseHash": "0e24a63c06c237bb62d21d1b9bdcc6d94c8e71c5"
+      },
+      "releaseTime": "2024-06-30T10:24:41Z",
+      "tarballUrl": "https://codeload.github.com/TeamRobotmad/BadgeBot/legacy.tar.gz/0e24a63c06c237bb62d21d1b9bdcc6d94c8e71c5",
+      "manifest": {
+        "app": {
+          "name": "BadgeBot",
+          "category": "Apps"
+        },
+        "metadata": {
+          "author": "Team Robotmad",
+          "license": "LGPL-3.0-only",
+          "url": "https://www.github.com/TeamRobotmad/BadgeBot",
+          "description": "A demo tildagon app for use with Hex Drive hexpansion ",
+          "version": "1.2.0"
+        }
+      }
+    },
+    {
+      "code": "12234024",
+      "id": {
+        "service": "github",
+        "owner": "analogue-stick",
+        "title": "badgemon",
+        "releaseHash": "ec4fb81212834ce2fdca76fd138d386425284ad5"
+      },
+      "releaseTime": "2024-06-19T19:41:13Z",
+      "tarballUrl": "https://codeload.github.com/analogue-stick/badgemon/legacy.tar.gz/ec4fb81212834ce2fdca76fd138d386425284ad5",
+      "manifest": {
+        "app": {
+          "name": "Badgemon Green",
+          "category": "Games"
+        },
+        "metadata": {
+          "author": "Analogue Stick",
+          "license": "CC-BY-NC-SA-4.0",
+          "url": "https://github.com/analogue-stick/badgemon",
+          "description": "A realworld creature collecting RPG for the Tildagon!",
+          "version": "1.0.6"
+        }
+      }
+    },
+    {
+      "code": "43031434",
+      "id": {
+        "service": "github",
+        "owner": "lucasjones",
+        "title": "pixelbadge",
+        "releaseHash": "3e9cadfd296289f948b087f302db8855217456cb"
+      },
+      "releaseTime": "2024-06-04T16:27:47Z",
+      "tarballUrl": "https://codeload.github.com/lucasjones/pixelbadge/legacy.tar.gz/3e9cadfd296289f948b087f302db8855217456cb",
+      "manifest": {
+        "app": {
+          "name": "BadgePixelArt",
+          "category": "Badge"
+        },
+        "metadata": {
+          "author": "lucasjones",
+          "license": "",
+          "url": "https://www.github.com/lucasjones/pixelbadge",
+          "description": "Pixel art animations (+ upload your own at pixelbadge.xyz)",
+          "version": "1.0.14"
+        }
+      }
+    },
+    {
+      "code": "43331430",
+      "id": {
+        "service": "github",
+        "owner": "jake-walker",
+        "title": "tildagon-bar-app",
+        "releaseHash": "d48c116bbe2ad0a906499925bd43a853b504802b"
+      },
+      "releaseTime": "2024-06-01T12:09:26Z",
+      "tarballUrl": "https://codeload.github.com/jake-walker/tildagon-bar-app/legacy.tar.gz/d48c116bbe2ad0a906499925bd43a853b504802b",
+      "manifest": {
+        "app": {
+          "name": "Bar",
+          "category": "Apps"
+        },
+        "metadata": {
+          "author": "jake-walker",
+          "license": "Unlicense",
+          "url": "https://github.com/jake-walker/tildagon-bar-app",
+          "description": "An app for browsing drinks available at the bars.",
+          "version": "0.0.3"
+        }
+      }
+    },
+    {
+      "code": "03210341",
+      "id": {
+        "service": "github",
+        "owner": "hughrawlinson",
+        "title": "tildagon-battery",
+        "releaseHash": "2dc035c6cdd4f6e0cb223d38f83b959d41f4f264"
+      },
+      "releaseTime": "2024-06-04T21:22:06Z",
+      "tarballUrl": "https://codeload.github.com/hughrawlinson/tildagon-battery/legacy.tar.gz/2dc035c6cdd4f6e0cb223d38f83b959d41f4f264",
+      "manifest": {
+        "app": {
+          "name": "Battery",
+          "category": "Badge"
+        },
+        "metadata": {
+          "author": "hughrawlinson",
+          "license": "LGPL-3.0-only",
+          "url": "https://www.github.com/hughrawlinson/battery",
+          "description": "See badge battery state",
+          "version": "0.4.0"
+        }
+      }
+    },
+    {
+      "code": "43040343",
+      "id": {
+        "service": "github",
+        "owner": "MatthewWilkes",
+        "title": "battery-background",
+        "releaseHash": "e2a82146cad3c4f73b5b441b409250a64d26b420"
+      },
+      "releaseTime": "2025-08-31T08:29:37Z",
+      "tarballUrl": "https://codeload.github.com/MatthewWilkes/battery-background/legacy.tar.gz/e2a82146cad3c4f73b5b441b409250a64d26b420",
+      "manifest": {
+        "app": {
+          "name": "Battery Background",
+          "category": "Background"
+        },
+        "metadata": {
+          "author": "MatthewWilkes",
+          "license": "LGPL-3.0-only",
+          "url": "https://www.github.com/matthewwilkes/battery-background",
+          "description": "Draw the battery state as part of the standard background",
+          "version": "1.0.1"
+        }
+      }
+    },
+    {
+      "code": "13011121",
+      "id": {
+        "service": "github",
+        "owner": "ChrisDick",
+        "title": "Tildagon-Battery-Icon",
+        "releaseHash": "ca8c85a0702ed148f5e79bd16fc5cc150e7bfdb7"
+      },
+      "releaseTime": "2025-09-14T21:13:04Z",
+      "tarballUrl": "https://codeload.github.com/ChrisDick/Tildagon-Battery-Icon/legacy.tar.gz/ca8c85a0702ed148f5e79bd16fc5cc150e7bfdb7",
+      "manifest": {
+        "app": {
+          "name": "Battery Icon",
+          "category": "Badge"
+        },
+        "metadata": {
+          "author": "ChrisDick",
+          "license": "MIT",
+          "url": "https://www.github.com/ChrisDick/tildagone",
+          "description": "Battery level icon app.",
+          "version": "0.0.1"
+        }
+      }
+    },
+    {
+      "code": "24422210",
+      "id": {
+        "service": "github",
+        "owner": "emericklaw",
+        "title": "tildagon-app-battery-meter",
+        "releaseHash": "0fe7c12554453f2a43acc55a8bd61b817c9ecdd1"
+      },
+      "releaseTime": "2025-05-14T00:44:03Z",
+      "tarballUrl": "https://codeload.github.com/emericklaw/tildagon-app-battery-meter/legacy.tar.gz/0fe7c12554453f2a43acc55a8bd61b817c9ecdd1",
+      "manifest": {
+        "app": {
+          "name": "Battery Meter",
+          "category": "Apps"
+        },
+        "metadata": {
+          "author": "Matt Emerick-Law",
+          "license": "MIT",
+          "url": "https://github.com/emericklaw/tildagon-app-battery-meter/",
+          "description": "Shows detailed information about the battery percentage, voltage levels and charging state.",
+          "version": "0.2.0"
+        }
+      }
+    },
+    {
+      "code": "04404320",
+      "id": {
+        "service": "github",
+        "owner": "cibomahto",
+        "title": "tildagon-batteryvoltage",
+        "releaseHash": "c0522c9a28123369b75ce0bca9087e8255963973"
+      },
+      "releaseTime": "2024-06-01T19:14:15Z",
+      "tarballUrl": "https://codeload.github.com/cibomahto/tildagon-batteryvoltage/legacy.tar.gz/c0522c9a28123369b75ce0bca9087e8255963973",
+      "manifest": {
+        "app": {
+          "name": "Battery Voltage",
+          "category": "Badge"
+        },
+        "metadata": {
+          "author": "cibomahto",
+          "license": "LGPL-3.0-only",
+          "url": "https://github.com/cibomahto/tildagon-batteryvoltage",
+          "description": "Check the battery voltage",
+          "version": "0.0.1"
+        }
+      }
+    },
+    {
+      "code": "03113243",
+      "id": {
+        "service": "github",
+        "owner": "archey347",
+        "title": "tildagon-app-scouts",
+        "releaseHash": "05c4a494363e4fec995cd0261efad210dcc416fd"
+      },
+      "releaseTime": "2024-10-04T00:42:47Z",
+      "tarballUrl": "https://codeload.github.com/archey347/tildagon-app-scouts/legacy.tar.gz/05c4a494363e4fec995cd0261efad210dcc416fd",
+      "manifest": {
+        "app": {
+          "name": "BEAST CAMP",
+          "category": "Apps"
+        },
+        "metadata": {
+          "author": "archey347",
+          "license": "LGPL-3.0-only",
+          "url": "https://www.github.com/archey347/tildagon-app-scouts",
+          "description": "An app for BEAST camp 2024!",
+          "version": "0.2.2"
+        }
+      }
+    },
+    {
+      "code": "43342433",
+      "id": {
+        "service": "github",
+        "owner": "PaperclipBadger",
+        "title": "badgebattery",
+        "releaseHash": "fd31ff84a6525290abcbebb493f23c133c861613"
+      },
+      "releaseTime": "2024-06-02T01:47:16Z",
+      "tarballUrl": "https://codeload.github.com/PaperclipBadger/badgebattery/legacy.tar.gz/fd31ff84a6525290abcbebb493f23c133c861613",
+      "manifest": {
+        "app": {
+          "name": "Blaine's Battery",
+          "category": "Badge"
+        },
+        "metadata": {
+          "author": "Blaine",
+          "license": "MIT",
+          "url": "https://github.com/paperclipbadger/badgebattery",
+          "description": "A battery app that works!",
+          "version": "0.1"
+        }
+      }
+    },
+    {
+      "code": "01211412",
+      "id": {
+        "service": "github",
+        "owner": "PaperclipBadger",
+        "title": "badgeclock",
+        "releaseHash": "8135377844522af727b717f6155da5c6f0ee12f0"
+      },
+      "releaseTime": "2024-06-02T13:46:54Z",
+      "tarballUrl": "https://codeload.github.com/PaperclipBadger/badgeclock/legacy.tar.gz/8135377844522af727b717f6155da5c6f0ee12f0",
+      "manifest": {
+        "app": {
+          "name": "Blaine's Clock",
+          "category": "Badge"
+        },
+        "metadata": {
+          "author": "Blaine",
+          "license": "MIT",
+          "url": "https://github.com/paperclipbadger/badgeclock",
+          "description": "An analogue clock that usually doesn't crash!",
+          "version": "0.8"
+        }
+      }
+    },
+    {
+      "code": "30311214",
+      "id": {
+        "service": "github",
+        "owner": "ritesh",
+        "title": "tildagon-bling",
+        "releaseHash": "5e15bdd73a44103303b37511b839a56680afe7cd"
+      },
+      "releaseTime": "2024-06-01T06:50:34Z",
+      "tarballUrl": "https://codeload.github.com/ritesh/tildagon-bling/legacy.tar.gz/5e15bdd73a44103303b37511b839a56680afe7cd",
+      "manifest": {
+        "app": {
+          "name": "Bling!",
+          "category": "Apps"
+        },
+        "metadata": {
+          "author": "ritesh",
+          "license": "WTFPL",
+          "url": "https://www.github.com/ritesh/tildagon-bling",
+          "description": "A silly app that makes your badge blingy!",
+          "version": "0.0.1"
+        }
+      }
+    },
+    {
+      "code": "44221103",
+      "id": {
+        "service": "github",
+        "owner": "npentrel",
+        "title": "tildagon-breadboard-tester",
+        "releaseHash": "dc5295fa9e1dc4813c5b0460ba73da31db5deb3f"
+      },
+      "releaseTime": "2024-08-04T13:13:06Z",
+      "tarballUrl": "https://codeload.github.com/npentrel/tildagon-breadboard-tester/legacy.tar.gz/dc5295fa9e1dc4813c5b0460ba73da31db5deb3f",
+      "manifest": {
+        "app": {
+          "name": "Breadboard Tester",
+          "category": "Apps"
+        },
+        "metadata": {
+          "author": "naomi",
+          "license": "LGPL-3.0-only",
+          "url": "https://www.github.com/npentrel/tildagon-breadboard-tester",
+          "description": "Use only with breadboard hexpansions. Toggle the state of eGPIO and GPIO pins.",
+          "version": "0.0.2"
+        }
+      }
+    },
+    {
+      "code": "11201130",
+      "id": {
+        "service": "github",
+        "owner": "merlininthewoods",
+        "title": "tildagon-bubble",
+        "releaseHash": "f154c5c2e3056b883c896072a56b32ffa4890547"
+      },
+      "releaseTime": "2024-06-02T19:54:27Z",
+      "tarballUrl": "https://codeload.github.com/merlininthewoods/tildagon-bubble/legacy.tar.gz/f154c5c2e3056b883c896072a56b32ffa4890547",
+      "manifest": {
+        "app": {
+          "name": "Bubble",
+          "category": "Apps"
+        },
+        "metadata": {
+          "author": "Merlin Howse",
+          "license": "LGPL-3.0-only",
+          "url": "https://www.github.com/npentrel/tildagon-snake",
+          "description": "Simple spirit level aka bubble App",
+          "version": "1.0.0"
+        }
+      }
+    },
+    {
+      "code": "21403114",
+      "id": {
+        "service": "github",
+        "owner": "walkerdanny",
+        "title": "caffeine-jitters",
+        "releaseHash": "be3230741fc0cd33181f46e3dbc3c21d187161e0"
+      },
+      "releaseTime": "2024-06-20T22:17:39Z",
+      "tarballUrl": "https://codeload.github.com/walkerdanny/caffeine-jitters/legacy.tar.gz/be3230741fc0cd33181f46e3dbc3c21d187161e0",
+      "manifest": {
+        "app": {
+          "name": "Caffeine Jitters",
+          "category": "Apps"
+        },
+        "metadata": {
+          "author": "walkerdanny",
+          "license": "MIT",
+          "url": "https://github.com/walkerdanny/caffeine-jitters",
+          "description": "Companion app for the Club Mate haptics hexpansion. Up and down buttons change the jitter frequency!",
+          "version": "0.0.3"
+        }
+      }
+    },
+    {
+      "code": "32131231",
+      "id": {
+        "service": "github",
+        "owner": "ashhhleyyy",
+        "title": "tildagon-cat",
+        "releaseHash": "dcf7cc823080d41805824d963291b231b9150ab6"
+      },
+      "releaseTime": "2024-06-01T22:46:19Z",
+      "tarballUrl": "https://codeload.github.com/ashhhleyyy/tildagon-cat/legacy.tar.gz/dcf7cc823080d41805824d963291b231b9150ab6",
+      "manifest": {
+        "app": {
+          "name": "Cat App",
+          "category": "Badge"
+        },
+        "metadata": {
+          "author": "ashhhleyyy",
+          "license": "MPL-2.0",
+          "url": "https://github.com/ashhhleyyy/tildagon-cat",
+          "description": "a lil cat for your badge, you can even pet the cutie :3",
+          "version": "0.0.1"
+        }
+      }
+    },
+    {
+      "code": "24431313",
+      "id": {
+        "service": "github",
+        "owner": "tomsci",
+        "title": "tildagon-clock",
+        "releaseHash": "9dd787b01b88b495a5afb8d3993cc5b8277e958d"
+      },
+      "releaseTime": "2024-06-02T12:23:04Z",
+      "tarballUrl": "https://codeload.github.com/tomsci/tildagon-clock/legacy.tar.gz/9dd787b01b88b495a5afb8d3993cc5b8277e958d",
+      "manifest": {
+        "app": {
+          "name": "Clock",
+          "category": "Badge"
+        },
+        "metadata": {
+          "author": "tomsci",
+          "license": "LGPL-3.0-only",
+          "url": "https://www.github.com/tomsci/tildagon-clock",
+          "description": "A Simple analogue clock",
+          "version": "0.2.0"
+        }
+      }
+    },
+    {
+      "code": "01130014",
+      "id": {
+        "service": "github",
+        "owner": "edent",
+        "title": "tildagon-clocky",
+        "releaseHash": "bc0119a27a7cd6e46e0551fb1078e726f0a173b8"
+      },
+      "releaseTime": "2024-06-12T07:06:19Z",
+      "tarballUrl": "https://codeload.github.com/edent/tildagon-clocky/legacy.tar.gz/bc0119a27a7cd6e46e0551fb1078e726f0a173b8",
+      "manifest": {
+        "app": {
+          "name": "Clocky",
+          "category": "Badge"
+        },
+        "metadata": {
+          "author": "edent",
+          "license": "MIT",
+          "url": "https://github.com/edent/tildagon-clocky",
+          "description": "A clock / watch for your Tildagon. Hardcoded to BST.",
+          "version": "0.0.1"
+        }
+      }
+    },
+    {
+      "code": "40132000",
+      "id": {
+        "service": "github",
+        "owner": "Davermouse",
+        "title": "hexbadge",
+        "releaseHash": "69bd870cc9e8c60f2d89c732a235b218c3944816"
+      },
+      "releaseTime": "2024-06-02T08:51:15Z",
+      "tarballUrl": "https://codeload.github.com/Davermouse/hexbadge/legacy.tar.gz/69bd870cc9e8c60f2d89c732a235b218c3944816",
+      "manifest": {
+        "app": {
+          "name": "DM HexBadge",
+          "category": "Badge"
+        },
+        "metadata": {
+          "author": "davermouse",
+          "license": "0BSD",
+          "url": "https://github.com/Davermouse/hexbadge",
+          "description": "A simple badge app with some spinning hexagons",
+          "version": "0.0.2"
+        }
+      }
+    },
+    {
+      "code": "31212103",
+      "id": {
+        "service": "github",
+        "owner": "andypiper",
+        "title": "emf-duckfacts-tildagon",
+        "releaseHash": "4825f06a2e7c86320b7794fbcf8af3bf8261d912"
+      },
+      "releaseTime": "2024-06-13T13:17:27Z",
+      "tarballUrl": "https://codeload.github.com/andypiper/emf-duckfacts-tildagon/legacy.tar.gz/4825f06a2e7c86320b7794fbcf8af3bf8261d912",
+      "manifest": {
+        "app": {
+          "name": "Duck Facts",
+          "category": "Apps"
+        },
+        "metadata": {
+          "author": "andypiper",
+          "license": "MIT",
+          "url": "https://github.com/andypiper/emf-duckfacts-tildagon",
+          "description": "Important Duck Facts for your Tildagon",
+          "version": "0.0.1"
+        }
+      }
+    },
+    {
+      "code": "14401443",
+      "id": {
+        "service": "github",
+        "owner": "jimmu",
+        "title": "badge-a-sketch",
+        "releaseHash": "9d20e841d5bd1a18258184e025e9ad394be4ba3d"
+      },
+      "releaseTime": "2024-06-27T09:04:17Z",
+      "tarballUrl": "https://codeload.github.com/jimmu/badge-a-sketch/legacy.tar.gz/9d20e841d5bd1a18258184e025e9ad394be4ba3d",
+      "manifest": {
+        "app": {
+          "name": "Echt-A-Sketch",
+          "category": "Badge"
+        },
+        "metadata": {
+          "author": "Jimmu",
+          "license": "MIT",
+          "url": "https://github.com/jimmu/badge-a-sketch/",
+          "description": "Frustrating drawing tool. Shake upside down to erase.",
+          "version": "0.1"
+        }
+      }
+    },
+    {
+      "code": "14211101",
+      "id": {
+        "service": "github",
+        "owner": "eehackspace",
+        "title": "tildagon-app-eehneopixellogo",
+        "releaseHash": "de94fef99ff90a84efeb79a6701aeaedc3849505"
+      },
+      "releaseTime": "2024-06-04T22:34:53Z",
+      "tarballUrl": "https://codeload.github.com/eehackspace/tildagon-app-eehneopixellogo/legacy.tar.gz/de94fef99ff90a84efeb79a6701aeaedc3849505",
+      "manifest": {
+        "app": {
+          "name": "EEH Logo",
+          "category": "Apps"
+        },
+        "metadata": {
+          "author": "Matt Emerick-Law",
+          "license": "MIT",
+          "url": "https://github.com/eehackspace/tildagon-app-eehneopixellogo/",
+          "description": "App for controlling the NeoPixels on the EEH LED Logo Hexpansion. Come see us at EMF 2026 if you want to buy one of our hexpansions.",
+          "version": "0.2.1"
+        }
+      }
+    },
+    {
+      "code": "14102304",
+      "id": {
+        "service": "github",
+        "owner": "pikesley",
+        "title": "tildagon-countdown",
+        "releaseHash": "5738a3c93c8184b2e930b968af9803cb06111229"
+      },
+      "releaseTime": "2025-07-27T13:41:05Z",
+      "tarballUrl": "https://codeload.github.com/pikesley/tildagon-countdown/legacy.tar.gz/5738a3c93c8184b2e930b968af9803cb06111229",
+      "manifest": {
+        "app": {
+          "name": "EMF 2026 Countdown",
+          "category": "Badge"
+        },
+        "metadata": {
+          "author": "pikesley",
+          "license": "MIT",
+          "url": "https://www.github.com/pikesley/tildagon-countdown",
+          "description": "Countdown to EMF 2026. Up and Down buttons to change the units.",
+          "version": "0.0.6"
+        }
+      }
+    },
+    {
+      "code": "14103433",
+      "id": {
+        "service": "github",
+        "owner": "pikesley",
+        "title": "tildagon-emf-cave",
+        "releaseHash": "688129d3b216a026fcfd5c6654211e80626827c8"
+      },
+      "releaseTime": "2025-02-08T11:45:46Z",
+      "tarballUrl": "https://codeload.github.com/pikesley/tildagon-emf-cave/legacy.tar.gz/688129d3b216a026fcfd5c6654211e80626827c8",
+      "manifest": {
+        "app": {
+          "name": "EMF Cave",
+          "category": "Games"
+        },
+        "metadata": {
+          "author": "pikesley",
+          "license": "MIT",
+          "url": "https://www.github.com/pikesley/tildagon-emf-cave",
+          "description": "A reimplementation of an ancient Palm Pilot game, SFCave",
+          "version": "0.0.2"
+        }
+      }
+    },
+    {
+      "code": "43324220",
+      "id": {
+        "service": "github",
+        "owner": "martin-hamilton",
+        "title": "EMF-Day",
+        "releaseHash": "bbaa5c8f59af8fe14d27455bcf41ea39d3c1fc65"
+      },
+      "releaseTime": "2024-06-13T15:54:12Z",
+      "tarballUrl": "https://codeload.github.com/martin-hamilton/EMF-Day/legacy.tar.gz/bbaa5c8f59af8fe14d27455bcf41ea39d3c1fc65",
+      "manifest": {
+        "app": {
+          "name": "EMF_Day",
+          "category": "Badge"
+        },
+        "metadata": {
+          "author": "MartinH",
+          "license": "LGPL-3.0-only",
+          "url": "https://github.com/martin-hamilton/EMF-DAY",
+          "description": "EMF never ended. Find out what day of the festival it is today.",
+          "version": "0.0.1"
+        }
+      }
+    },
+    {
+      "code": "22302414",
+      "id": {
+        "service": "github",
+        "owner": "martin-hamilton",
+        "title": "EMF-Spinner",
+        "releaseHash": "09a0aae29b4ec29fdf259585361a29b43fbabe95"
+      },
+      "releaseTime": "2024-06-20T22:33:16Z",
+      "tarballUrl": "https://codeload.github.com/martin-hamilton/EMF-Spinner/legacy.tar.gz/09a0aae29b4ec29fdf259585361a29b43fbabe95",
+      "manifest": {
+        "app": {
+          "name": "EMF_Spinner",
+          "category": "Badge"
+        },
+        "metadata": {
+          "author": "MartinH",
+          "license": "LGPL-3.0-only",
+          "url": "https://github.com/martin-hamilton/EMF-Spinner",
+          "description": "Spinny EMF 2024 logo with trippy background colours",
+          "version": "0.0.1"
+        }
+      }
+    },
+    {
+      "code": "00303310",
+      "id": {
+        "service": "github",
+        "owner": "mbooth101",
+        "title": "emf-eyapp",
+        "releaseHash": "4018010f32c7a2a6f26a2d3073286d61cbdf68d7"
+      },
+      "releaseTime": "2024-06-16T18:31:45Z",
+      "tarballUrl": "https://codeload.github.com/mbooth101/emf-eyapp/legacy.tar.gz/4018010f32c7a2a6f26a2d3073286d61cbdf68d7",
+      "manifest": {
+        "app": {
+          "name": "Ey App",
+          "category": "Apps"
+        },
+        "metadata": {
+          "author": "mbooth",
+          "license": "MIT",
+          "url": "https://github.com/mbooth101/emf-eyapp",
+          "description": "A northerner simulator.",
+          "version": "8"
+        }
+      }
+    },
+    {
+      "code": "11341231",
+      "id": {
+        "service": "github",
+        "owner": "FerNerd",
+        "title": "tildagon-ferdi-app",
+        "releaseHash": "36cf5e5e0ada3d8f202044529573428ebff501b9"
+      },
+      "releaseTime": "2024-06-01T23:16:37Z",
+      "tarballUrl": "https://codeload.github.com/FerNerd/tildagon-ferdi-app/legacy.tar.gz/36cf5e5e0ada3d8f202044529573428ebff501b9",
+      "manifest": {
+        "app": {
+          "name": "Ferdi App",
+          "category": "Badge"
+        },
+        "metadata": {
+          "author": "ferdinandsmit",
+          "license": "LGPL-3.0-only",
+          "url": "https://github.com/Smitplaza/tildagon-ferdi-app",
+          "description": "My Cool Tildagon App",
+          "version": "0.0.11"
+        }
+      }
+    },
+    {
+      "code": "03411304",
+      "id": {
+        "service": "github",
+        "owner": "AndreasThinks",
+        "title": "tildagon-flappy-boy",
+        "releaseHash": "0fba1c174c1d6a541d3200b3a8098442f3477f4a"
+      },
+      "releaseTime": "2024-05-31T13:53:38Z",
+      "tarballUrl": "https://codeload.github.com/AndreasThinks/tildagon-flappy-boy/legacy.tar.gz/0fba1c174c1d6a541d3200b3a8098442f3477f4a",
+      "manifest": {
+        "app": {
+          "name": "Flappy Boy",
+          "category": "Games"
+        },
+        "metadata": {
+          "author": "AndreasThinks",
+          "license": "LGPL-3.0-only",
+          "url": "https://github.com/AndreasThinks/tildagon-flappy-boy",
+          "description": "A Flappy Bird style game",
+          "version": "0.0.1"
+        }
+      }
+    },
+    {
+      "code": "43014004",
+      "id": {
+        "service": "github",
+        "owner": "chaos-dotcom",
+        "title": "fluroclockapp",
+        "releaseHash": "3462c88f905aac219bc8f9dd4f9a1cbebdb2b587"
+      },
+      "releaseTime": "2024-06-13T23:40:38Z",
+      "tarballUrl": "https://codeload.github.com/chaos-dotcom/fluroclockapp/legacy.tar.gz/3462c88f905aac219bc8f9dd4f9a1cbebdb2b587",
+      "manifest": {
+        "app": {
+          "name": "Fluroclock",
+          "category": "Media"
+        },
+        "metadata": {
+          "author": "John Rogers & Ben Eriksson",
+          "license": "MIT",
+          "url": "https://github.com/Johnr24/fluroclockapp",
+          "description": "Control the Fluroclock at EMF, from your badge!",
+          "version": "0.0.5"
+        }
+      }
+    },
+    {
+      "code": "43421204",
+      "id": {
+        "service": "github",
+        "owner": "Kimbsy",
+        "title": "tildagon-life",
+        "releaseHash": "1abf63139919532966b818bc82b578ba922f3da6"
+      },
+      "releaseTime": "2024-06-01T18:33:06Z",
+      "tarballUrl": "https://codeload.github.com/Kimbsy/tildagon-life/legacy.tar.gz/1abf63139919532966b818bc82b578ba922f3da6",
+      "manifest": {
+        "app": {
+          "name": "Game of Life",
+          "category": "Games"
+        },
+        "metadata": {
+          "author": "Kimbsy",
+          "license": "LGPL-3.0-only",
+          "url": "https://github.com/Kimbsy/tildagon-life",
+          "description": "Simulate Life exactly as Conway imagined it",
+          "version": "0.0.7"
+        }
+      }
+    },
+    {
+      "code": "34011133",
+      "id": {
+        "service": "github",
+        "owner": "gchq-net",
+        "title": "badge-app",
+        "releaseHash": "b9834f3d7b3d79f4c6a0410f0f0292361269948a"
+      },
+      "releaseTime": "2024-05-31T16:09:19Z",
+      "tarballUrl": "https://codeload.github.com/gchq-net/badge-app/legacy.tar.gz/b9834f3d7b3d79f4c6a0410f0f0292361269948a",
+      "manifest": {
+        "app": {
+          "name": "GCHQ.NET",
+          "category": "Badge"
+        },
+        "metadata": {
+          "author": "GCHQ.NET",
+          "license": "LGPL-3.0-only",
+          "url": "https://github.com/gchq-net/badge-app",
+          "description": "GCHQ Badge companion app",
+          "version": "0.4.1"
+        }
+      }
+    },
+    {
+      "code": "44412014",
+      "id": {
+        "service": "github",
+        "owner": "usedbytes",
+        "title": "tildagon-ballcage",
+        "releaseHash": "b5c10cada11ce96189e53cba668506f2b16ab469"
+      },
+      "releaseTime": "2024-06-02T10:58:28Z",
+      "tarballUrl": "https://codeload.github.com/usedbytes/tildagon-ballcage/legacy.tar.gz/b5c10cada11ce96189e53cba668506f2b16ab469",
+      "manifest": {
+        "app": {
+          "name": "Googly",
+          "category": "Badge"
+        },
+        "metadata": {
+          "author": "usedbytes",
+          "license": "LGPL-3.0-only",
+          "url": "https://github.com/usedbytes/tildagon-ballcage",
+          "description": "A Googly Eye. Everyone loves Googly Eyes. The physics is a bit jank.",
+          "version": "0.0.4"
+        }
+      }
+    },
+    {
+      "code": "44024034",
+      "id": {
+        "service": "github",
+        "owner": "AgentAntelope",
+        "title": "grayme_badge",
+        "releaseHash": "b552e0a2dcf49a23b5dc4f6efd49c1f0b730ff22"
+      },
+      "releaseTime": "2024-06-05T08:53:03Z",
+      "tarballUrl": "https://codeload.github.com/AgentAntelope/grayme_badge/legacy.tar.gz/b552e0a2dcf49a23b5dc4f6efd49c1f0b730ff22",
+      "manifest": {
+        "app": {
+          "name": "GraymeBadge",
+          "category": "Badge"
+        },
+        "metadata": {
+          "author": "AgentAntelope",
+          "license": "Unlicense",
+          "url": "https://github.com/AgentAntelope/grayme_badge/",
+          "description": "A greyscale 'Hello my name is' sticker style Tildagon name badge. Rendering based on jake-walker's",
+          "version": "0.0.3"
+        }
+      }
+    },
+    {
+      "code": "21201202",
+      "id": {
+        "service": "github",
+        "owner": "ChrisDick",
+        "title": "Tildagon-Pattern-Example",
+        "releaseHash": "ccb75aa3e0a5c03548eb503eedb0864f026d47d7"
+      },
+      "releaseTime": "2025-08-31T17:17:45Z",
+      "tarballUrl": "https://codeload.github.com/ChrisDick/Tildagon-Pattern-Example/legacy.tar.gz/ccb75aa3e0a5c03548eb503eedb0864f026d47d7",
+      "manifest": {
+        "app": {
+          "name": "green flash",
+          "category": "Pattern"
+        },
+        "metadata": {
+          "author": "Chris Dick",
+          "license": "MIT",
+          "url": "https://github.com/chrisdick/tildagon-pattern-green-flash/",
+          "description": "green version of the built in flash pattern for testing led sequence feature",
+          "version": "0.0.1"
+        }
+      }
+    },
+    {
+      "code": "41202202",
+      "id": {
+        "service": "github",
+        "owner": "ThomasJackDalby",
+        "title": "tildagon-flashy",
+        "releaseHash": "6953d232144f3c65c1e0e4d1bb6cb6a3e911c8ee"
+      },
+      "releaseTime": "2024-06-02T15:40:45Z",
+      "tarballUrl": "https://codeload.github.com/ThomasJackDalby/tildagon-flashy/legacy.tar.gz/6953d232144f3c65c1e0e4d1bb6cb6a3e911c8ee",
+      "manifest": {
+        "app": {
+          "name": "HAB Flash",
+          "category": "Badge"
+        },
+        "metadata": {
+          "author": "Tom Dalby",
+          "license": "MIT",
+          "url": "https://github.com/ThomasJackDalby/tildagon-flashy",
+          "description": "The essential navigation (and tracking) tool for EMF 2024. Allows the wearer to beam their current location to HABVille, through the medium of receipt printing. (to be clear, this will actually print a physical receipt of your location at HABVille (during EMF 2024)).",
+          "version": "0.0.4"
+        }
+      }
+    },
+    {
+      "code": "22012331",
+      "id": {
+        "service": "github",
+        "owner": "samtygier",
+        "title": "tildagon-hacktheplanet",
+        "releaseHash": "4d6324e4ff44339ef1b3d0f69d73c6f77fc6e3b4"
+      },
+      "releaseTime": "2024-06-02T16:16:14Z",
+      "tarballUrl": "https://codeload.github.com/samtygier/tildagon-hacktheplanet/legacy.tar.gz/4d6324e4ff44339ef1b3d0f69d73c6f77fc6e3b4",
+      "manifest": {
+        "app": {
+          "name": "Hack the Planet",
+          "category": "Badge"
+        },
+        "metadata": {
+          "author": "Sam Tygier",
+          "license": "LGPL-3.0-only",
+          "url": "https://www.github.com/samtygier/tildagon-hacktheplanet",
+          "description": "Hack the Planet",
+          "version": "0.0.6"
+        }
+      }
+    },
+    {
+      "code": "10113043",
+      "id": {
+        "service": "github",
+        "owner": "jake-walker",
+        "title": "tildagon-name-badge",
+        "releaseHash": "07aca4cbac964de37b77941668e3ead2807955ca"
+      },
+      "releaseTime": "2024-05-31T18:39:32Z",
+      "tarballUrl": "https://codeload.github.com/jake-walker/tildagon-name-badge/legacy.tar.gz/07aca4cbac964de37b77941668e3ead2807955ca",
+      "manifest": {
+        "app": {
+          "name": "Hello Name Badge",
+          "category": "Badge"
+        },
+        "metadata": {
+          "author": "jake-walker",
+          "license": "Unlicense",
+          "url": "https://github.com/jake-walker/tildagon-name-badge",
+          "description": "A simple 'Hello my name is' sticker style Tildagon name badge",
+          "version": "0.0.3"
+        }
+      }
+    },
+    {
+      "code": "34143123",
+      "id": {
+        "service": "github",
+        "owner": "emfcamp",
+        "title": "badge-2024-apps-hexfile",
+        "releaseHash": "e8b783349eda65e582b4fcaf44204a072551157a"
+      },
+      "releaseTime": "2025-03-03T22:52:49Z",
+      "tarballUrl": "https://codeload.github.com/emfcamp/badge-2024-apps-hexfile/legacy.tar.gz/e8b783349eda65e582b4fcaf44204a072551157a",
+      "manifest": {
+        "app": {
+          "name": "Hexfile",
+          "category": "Badge"
+        },
+        "metadata": {
+          "author": "ChrisDick",
+          "license": "MIT",
+          "url": "https://www.github.com/emfcamp/badge-2024-apps-hexfile",
+          "description": "File explorer with Cut, Copy, Paste, Delete, Rename and mkdir. Can copy files and folders up to 3 levels deep onto any mounted storage.",
+          "version": "1.0.0"
+        }
+      }
+    },
+    {
+      "code": "21431034",
+      "id": {
+        "service": "github",
+        "owner": "DolicaAkelloEgwel",
+        "title": "ikeda-type-beat",
+        "releaseHash": "b7fc8a414a146596ec5da628bc218d4d11e9bdde"
+      },
+      "releaseTime": "2024-06-25T14:15:18Z",
+      "tarballUrl": "https://codeload.github.com/DolicaAkelloEgwel/ikeda-type-beat/legacy.tar.gz/b7fc8a414a146596ec5da628bc218d4d11e9bdde",
+      "manifest": {
+        "app": {
+          "name": "Ikeda Type Beat",
+          "category": "Badge"
+        },
+        "metadata": {
+          "author": "DolicaAkelloEgwel",
+          "license": "LGPL-3.0-only",
+          "url": "https://github.com/DolicaAkelloEgwel/ikeda-type-beat",
+          "description": "Some visuals inspired by Ryoji Ikeda. Use the A and D buttons to switch between different modes.",
+          "version": "0.0.4"
+        }
+      }
+    },
+    {
+      "code": "32042424",
+      "id": {
+        "service": "github",
+        "owner": "npentrel",
+        "title": "imu-readings",
+        "releaseHash": "95145317228ecdf2de6d3f1c332d170a7625e79d"
+      },
+      "releaseTime": "2024-06-02T10:45:51Z",
+      "tarballUrl": "https://codeload.github.com/npentrel/imu-readings/legacy.tar.gz/95145317228ecdf2de6d3f1c332d170a7625e79d",
+      "manifest": {
+        "app": {
+          "name": "IMU Readings",
+          "category": "Games"
+        },
+        "metadata": {
+          "author": "naomi",
+          "license": "LGPL-3.0-only",
+          "url": "https://www.github.com/npentrel/imu-readings",
+          "description": "See the readings of the IMU as you move the badge.",
+          "version": "1.0.0"
+        }
+      }
+    },
+    {
+      "code": "23140312",
+      "id": {
+        "service": "github",
+        "owner": "LGDan",
+        "title": "Tildagon_IP_App",
+        "releaseHash": "0b9c50197c04533a43566d23c2f7e1a787c3ebb5"
+      },
+      "releaseTime": "2024-05-31T16:46:04Z",
+      "tarballUrl": "https://codeload.github.com/LGDan/Tildagon_IP_App/legacy.tar.gz/0b9c50197c04533a43566d23c2f7e1a787c3ebb5",
+      "manifest": {
+        "app": {
+          "name": "IP Address",
+          "category": "Badge"
+        },
+        "metadata": {
+          "author": "LGDan",
+          "license": "LGPL-3.0-only",
+          "url": "https://github.com/LGDan/Tildagon_IP_App",
+          "description": "EMF 2024 App to get the IP of your badge.",
+          "version": "0.0.1"
+        }
+      }
+    },
+    {
+      "code": "21341132",
+      "id": {
+        "service": "github",
+        "owner": "pixelscript",
+        "title": "clock.json",
+        "releaseHash": "58f2f524e6636553d6f26cbdfb4cce4240b1e0a6"
+      },
+      "releaseTime": "2024-06-02T16:04:32Z",
+      "tarballUrl": "https://codeload.github.com/pixelscript/clock.json/legacy.tar.gz/58f2f524e6636553d6f26cbdfb4cce4240b1e0a6",
+      "manifest": {
+        "app": {
+          "name": "json clock",
+          "category": "Badge"
+        },
+        "metadata": {
+          "author": "pixelscript",
+          "license": "Apache-2.0",
+          "url": "https://www.github.com/pixelscript/clock.json",
+          "description": "A JSON style clock that uses your ip to work out local time.",
+          "version": "0.0.7"
+        }
+      }
+    },
+    {
+      "code": "13243023",
+      "id": {
+        "service": "github",
+        "owner": "DolicaAkelloEgwel",
+        "title": "magic-8-ball",
+        "releaseHash": "291b74159030ab045813ef5915a071e9965d3de3"
+      },
+      "releaseTime": "2024-06-27T13:09:46Z",
+      "tarballUrl": "https://codeload.github.com/DolicaAkelloEgwel/magic-8-ball/legacy.tar.gz/291b74159030ab045813ef5915a071e9965d3de3",
+      "manifest": {
+        "app": {
+          "name": "Magic 8 Ball",
+          "category": "Badge"
+        },
+        "metadata": {
+          "author": "DolicaAkelloEgwel",
+          "license": "LGPL-3.0-only",
+          "url": "https://github.com/DolicaAkelloEgwel/magic-8-ball",
+          "description": "Shake the Magic 8 Ball to learn your fate.",
+          "version": "0.0.1"
+        }
+      }
+    },
+    {
+      "code": "11223104",
+      "id": {
+        "service": "github",
+        "owner": "andreacampanella",
+        "title": "tildagon-Martrix",
+        "releaseHash": "50b2552da9599723da29f9c1209adddb34528cc2"
+      },
+      "releaseTime": "2024-06-01T11:17:54Z",
+      "tarballUrl": "https://codeload.github.com/andreacampanella/tildagon-Martrix/legacy.tar.gz/50b2552da9599723da29f9c1209adddb34528cc2",
+      "manifest": {
+        "app": {
+          "name": "Matrix rain",
+          "category": "Apps"
+        },
+        "metadata": {
+          "author": "emuboy",
+          "license": "LGPL-3.0-only",
+          "url": "https://github.com/andreacampanella/tildagon-Martrix",
+          "description": "Enter the Matrix",
+          "version": "0.0.1"
+        }
+      }
+    },
+    {
+      "code": "04404121",
+      "id": {
+        "service": "github",
+        "owner": "MatthewWilkes",
+        "title": "md-updater",
+        "releaseHash": "d14b0259e9e07f3384c0b8f978d6a48d80bd65f0"
+      },
+      "releaseTime": "2025-08-24T16:58:10Z",
+      "tarballUrl": "https://codeload.github.com/MatthewWilkes/md-updater/legacy.tar.gz/d14b0259e9e07f3384c0b8f978d6a48d80bd65f0",
+      "manifest": {
+        "app": {
+          "name": "MD Updater",
+          "category": "Badge"
+        },
+        "metadata": {
+          "author": "Matthew Wilkes",
+          "license": "LGPL-3.0-only",
+          "url": "https://www.github.com/username/repo",
+          "description": "A utility to update the firmware of the Megadrive interface hexpansion",
+          "version": "2.0.1"
+        }
+      }
+    },
+    {
+      "code": "23223401",
+      "id": {
+        "service": "github",
+        "owner": "pikesley",
+        "title": "tildagon-miner",
+        "releaseHash": "361c869d6c350a6d052f3217fa88fd132c43ad76"
+      },
+      "releaseTime": "2025-02-16T16:16:07Z",
+      "tarballUrl": "https://codeload.github.com/pikesley/tildagon-miner/legacy.tar.gz/361c869d6c350a6d052f3217fa88fd132c43ad76",
+      "manifest": {
+        "app": {
+          "name": "Miner",
+          "category": "Games"
+        },
+        "metadata": {
+          "author": "pikesley",
+          "license": "MIT",
+          "url": "https://www.github.com/tildagon-miner",
+          "description": "Miner Willy wandering around your Tildagon",
+          "version": "0.0.1"
+        }
+      }
+    },
+    {
+      "code": "41320402",
+      "id": {
+        "service": "github",
+        "owner": "estuans",
+        "title": "tildagon-multiclock",
+        "releaseHash": "b79cd1b43e4476323102a695df1181c7e9865378"
+      },
+      "releaseTime": "2024-06-14T13:44:29Z",
+      "tarballUrl": "https://codeload.github.com/estuans/tildagon-multiclock/legacy.tar.gz/b79cd1b43e4476323102a695df1181c7e9865378",
+      "manifest": {
+        "app": {
+          "name": "MultiClock",
+          "category": "Badge"
+        },
+        "metadata": {
+          "author": "estuans",
+          "license": "LGPL-3.0-only",
+          "url": "https://www.github.com/estuans/tildagon-multiclock",
+          "description": "A Clock with support for multiple faces",
+          "version": "0.2.3"
+        }
+      }
+    },
+    {
+      "code": "04022424",
+      "id": {
+        "service": "github",
+        "owner": "Cheukting",
+        "title": "tildagon-mystify",
+        "releaseHash": "847bb4fa455efe06e12ba8abca8022e6826435fa"
+      },
+      "releaseTime": "2024-06-04T17:03:33Z",
+      "tarballUrl": "https://codeload.github.com/Cheukting/tildagon-mystify/legacy.tar.gz/847bb4fa455efe06e12ba8abca8022e6826435fa",
+      "manifest": {
+        "app": {
+          "name": "Mystify",
+          "category": "Media"
+        },
+        "metadata": {
+          "author": "Cheukting",
+          "license": "LGPL-3.0-only",
+          "url": "https://github.com/Cheukting/tildagon-mystify",
+          "description": "Recreation of the classic Window 3.1 screensaver Mystify.",
+          "version": "0.1.0"
+        }
+      }
+    },
+    {
+      "code": "30302422",
+      "id": {
+        "service": "github",
+        "owner": "AaronJackson",
+        "title": "tildagon-nottinghack-logo",
+        "releaseHash": "25297213e87033991f0a7a2f34c35c7f38e1df34"
+      },
+      "releaseTime": "2024-06-05T22:47:44Z",
+      "tarballUrl": "https://codeload.github.com/AaronJackson/tildagon-nottinghack-logo/legacy.tar.gz/25297213e87033991f0a7a2f34c35c7f38e1df34",
+      "manifest": {
+        "app": {
+          "name": "NottingHack Logo",
+          "category": "Badge"
+        },
+        "metadata": {
+          "author": "aaronjackson",
+          "license": "LGPL-3.0-only",
+          "url": "https://www.github.com/aaronjackson/tildagon-nottinghack-logo",
+          "description": "Shows nottinghack logo",
+          "version": "0.0.1"
+        }
+      }
+    },
+    {
+      "code": "32224030",
+      "id": {
+        "service": "github",
+        "owner": "emericklaw",
+        "title": "tildagon-app-pacman-led",
+        "releaseHash": "6b44e7a317e84ace5ccb2178b4cfe05cce11aced"
+      },
+      "releaseTime": "2024-06-27T10:26:03Z",
+      "tarballUrl": "https://codeload.github.com/emericklaw/tildagon-app-pacman-led/legacy.tar.gz/6b44e7a317e84ace5ccb2178b4cfe05cce11aced",
+      "manifest": {
+        "app": {
+          "name": "Pacman LED",
+          "category": "Apps"
+        },
+        "metadata": {
+          "author": "Matt Emerick-Law",
+          "license": "MIT",
+          "url": "https://github.com/emericklaw/tildagon-app-pacman-led/",
+          "description": "Control the LEDs on the Pacman hexpansion created by The Untitled Goose.",
+          "version": "0.1.0"
+        }
+      }
+    },
+    {
+      "code": "34030143",
+      "id": {
+        "service": "github",
+        "owner": "pikesley",
+        "title": "tildagon-particle-man",
+        "releaseHash": "8ff2ea9063163fcd29730b4d14fa1dde92b27061"
+      },
+      "releaseTime": "2025-02-28T14:54:23Z",
+      "tarballUrl": "https://codeload.github.com/pikesley/tildagon-particle-man/legacy.tar.gz/8ff2ea9063163fcd29730b4d14fa1dde92b27061",
+      "manifest": {
+        "app": {
+          "name": "Particle Man",
+          "category": "Games"
+        },
+        "metadata": {
+          "author": "pikesley",
+          "license": "MIT",
+          "url": "https://www.github.com/pikesley/tildagon-particle-man",
+          "description": "Elastically-colliding particles",
+          "version": "0.0.2"
+        }
+      }
+    },
+    {
+      "code": "20101301",
+      "id": {
+        "service": "github",
+        "owner": "oholiab",
+        "title": "tildagon-pentagram-app",
+        "releaseHash": "509c876427e92a70be71fdbe2f44dea0275eaad0"
+      },
+      "releaseTime": "2024-06-02T16:12:09Z",
+      "tarballUrl": "https://codeload.github.com/oholiab/tildagon-pentagram-app/legacy.tar.gz/509c876427e92a70be71fdbe2f44dea0275eaad0",
+      "manifest": {
+        "app": {
+          "name": "Pentagram",
+          "category": "Badge"
+        },
+        "metadata": {
+          "author": "grimmware",
+          "license": "WTFPL",
+          "url": "https://github.com/oholiab/tildagon-pentagram-app",
+          "description": "EMF 2024 App to invoke dark powers.",
+          "version": "0.0.3"
+        }
+      }
+    },
+    {
+      "code": "30042022",
+      "id": {
+        "service": "github",
+        "owner": "ProtonNumber",
+        "title": "PrideCircles",
+        "releaseHash": "1dcc05ed6ebdf6e696d158dc250ec2da61ba80a0"
+      },
+      "releaseTime": "2024-06-02T17:51:06Z",
+      "tarballUrl": "https://codeload.github.com/ProtonNumber/PrideCircles/legacy.tar.gz/1dcc05ed6ebdf6e696d158dc250ec2da61ba80a0",
+      "manifest": {
+        "app": {
+          "name": "PrideCircles",
+          "category": "Badge"
+        },
+        "metadata": {
+          "author": "Claire",
+          "license": "LGPL-3.0-only",
+          "url": "https://github.com/ProtonNumber/PrideCircles",
+          "description": "A simple pride flag visualiser, but circles! Use the B / E buttons to cycle through flags, use A / D to control brightness. Now with LEDs!",
+          "version": "0.2.0"
+        }
+      }
+    },
+    {
+      "code": "13320241",
+      "id": {
+        "service": "github",
+        "owner": "RichardoC",
+        "title": "richard-name-badge",
+        "releaseHash": "7e0501f73479ebe3c5bef8cf6602162838f5d317"
+      },
+      "releaseTime": "2024-06-01T12:52:11Z",
+      "tarballUrl": "https://codeload.github.com/RichardoC/richard-name-badge/legacy.tar.gz/7e0501f73479ebe3c5bef8cf6602162838f5d317",
+      "manifest": {
+        "app": {
+          "name": "Richard name badge",
+          "category": "Badge"
+        },
+        "metadata": {
+          "author": "richardoc",
+          "license": "MIT",
+          "url": "https://github.com/RichardoC/richard-name-badge",
+          "description": " A badge if your name is Richard!",
+          "version": "0.0.1"
+        }
+      }
+    },
+    {
+      "code": "40204031",
+      "id": {
+        "service": "github",
+        "owner": "thomasmichaelwallace",
+        "title": "LeoSuit",
+        "releaseHash": "e4833378821df3952fcb8a9e494be6db74f7e50e"
+      },
+      "releaseTime": "2024-06-01T21:51:17Z",
+      "tarballUrl": "https://codeload.github.com/thomasmichaelwallace/LeoSuit/legacy.tar.gz/e4833378821df3952fcb8a9e494be6db74f7e50e",
+      "manifest": {
+        "app": {
+          "name": "roygbiVW",
+          "category": "Apps"
+        },
+        "metadata": {
+          "author": "thomasmichaelwallace",
+          "license": "MIT",
+          "url": "https://github.com/thomasmichaelwallace/leos-suit",
+          "description": "Control the roygbiVW LED van!",
+          "version": "0.0.6"
+        }
+      }
+    },
+    {
+      "code": "00344241",
+      "id": {
+        "service": "github",
+        "owner": "pikesley",
+        "title": "tildagon-bounce",
+        "releaseHash": "e80fe8b9a34022d237f83f084112b002fcb22951"
+      },
+      "releaseTime": "2025-02-07T22:28:55Z",
+      "tarballUrl": "https://codeload.github.com/pikesley/tildagon-bounce/legacy.tar.gz/e80fe8b9a34022d237f83f084112b002fcb22951",
+      "manifest": {
+        "app": {
+          "name": "Sam's Bouncing Blobs",
+          "category": "Games"
+        },
+        "metadata": {
+          "author": "pikesley",
+          "license": "MIT",
+          "url": "https://www.github.com/pikesley/tildagon-bounce",
+          "description": "Some bouncing blobs on your TIldagon. See the README for what the buttons do",
+          "version": "0.0.1"
+        }
+      }
+    },
+    {
+      "code": "00211123",
+      "id": {
+        "service": "github",
+        "owner": "pikesley",
+        "title": "tildagon-clock",
+        "releaseHash": "0783ecd4022af8839e8e14343fe6801914cc869b"
+      },
+      "releaseTime": "2025-02-07T22:16:54Z",
+      "tarballUrl": "https://codeload.github.com/pikesley/tildagon-clock/legacy.tar.gz/0783ecd4022af8839e8e14343fe6801914cc869b",
+      "manifest": {
+        "app": {
+          "name": "Sam's Clock",
+          "category": "Games"
+        },
+        "metadata": {
+          "author": "pikesley",
+          "license": "MIT",
+          "url": "https://www.github.com/pikesley/tildagon-clock",
+          "description": "Tell time on the Tildagon. See the README for what the buttons do",
+          "version": "0.0.8"
+        }
+      }
+    },
+    {
+      "code": "10444114",
+      "id": {
+        "service": "github",
+        "owner": "pikesley",
+        "title": "tildagon-simon",
+        "releaseHash": "657b21884c6792d4b7f9cfcfcabcc282b274d9d0"
+      },
+      "releaseTime": "2025-02-16T16:24:22Z",
+      "tarballUrl": "https://codeload.github.com/pikesley/tildagon-simon/legacy.tar.gz/657b21884c6792d4b7f9cfcfcabcc282b274d9d0",
+      "manifest": {
+        "app": {
+          "name": "Simon",
+          "category": "Games"
+        },
+        "metadata": {
+          "author": "pikesley",
+          "license": "MIT",
+          "url": "https://www.github.com/pikesley/tildagon-simon",
+          "description": "A reimplementation of an ancient game. Shake the badge to start or move to the next round",
+          "version": "0.0.3"
+        }
+      }
+    },
+    {
+      "code": "22421310",
+      "id": {
+        "service": "github",
+        "owner": "npentrel",
+        "title": "tildagon-snake",
+        "releaseHash": "c55f3c4cc7ecbc13f28c6965837b8d5a8e54e9ba"
+      },
+      "releaseTime": "2024-06-01T14:52:50Z",
+      "tarballUrl": "https://codeload.github.com/npentrel/tildagon-snake/legacy.tar.gz/c55f3c4cc7ecbc13f28c6965837b8d5a8e54e9ba",
+      "manifest": {
+        "app": {
+          "name": "Snake",
+          "category": "Games"
+        },
+        "metadata": {
+          "author": "naomi",
+          "license": "LGPL-3.0-only",
+          "url": "https://www.github.com/npentrel/tildagon-snake",
+          "description": "Play snake on your tildagon badge.",
+          "version": "1.0.0"
+        }
+      }
+    },
+    {
+      "code": "24013011",
+      "id": {
+        "service": "github",
+        "owner": "npentrel",
+        "title": "tildagon-snake-imu",
+        "releaseHash": "93b164d642292df170f0d995fd3ef8c86c37cb0d"
+      },
+      "releaseTime": "2024-06-01T14:54:01Z",
+      "tarballUrl": "https://codeload.github.com/npentrel/tildagon-snake-imu/legacy.tar.gz/93b164d642292df170f0d995fd3ef8c86c37cb0d",
+      "manifest": {
+        "app": {
+          "name": "SnakeIMU",
+          "category": "Games"
+        },
+        "metadata": {
+          "author": "naomi",
+          "license": "LGPL-3.0-only",
+          "url": "https://www.github.com/npentrel/tildagon-snake-imu",
+          "description": "Play snake by tilting your tildagon badge. Press CONFIRM to start.",
+          "version": "1.0.1"
+        }
+      }
+    },
+    {
+      "code": "03013144",
+      "id": {
+        "service": "github",
+        "owner": "pikesley",
+        "title": "tildagon-space-invaders",
+        "releaseHash": "b6df95f2ca8463f8c16db151013491c5a277aa9e"
+      },
+      "releaseTime": "2025-02-16T16:07:37Z",
+      "tarballUrl": "https://codeload.github.com/pikesley/tildagon-space-invaders/legacy.tar.gz/b6df95f2ca8463f8c16db151013491c5a277aa9e",
+      "manifest": {
+        "app": {
+          "name": "SpaceInvaders",
+          "category": "Games"
+        },
+        "metadata": {
+          "author": "pikesley",
+          "license": "MIT",
+          "url": "https://www.github.com/pikesley/tildagon-space-invaders",
+          "description": "Some Space Invaders on your Tildagon",
+          "version": "0.0.1"
+        }
+      }
+    },
+    {
+      "code": "01344223",
+      "id": {
+        "service": "github",
+        "owner": "MikeS159",
+        "title": "tildagon-speedtest",
+        "releaseHash": "d2803f7d111b281427d545654ee9f4de6ca384c6"
+      },
+      "releaseTime": "2024-06-02T10:35:42Z",
+      "tarballUrl": "https://codeload.github.com/MikeS159/tildagon-speedtest/legacy.tar.gz/d2803f7d111b281427d545654ee9f4de6ca384c6",
+      "manifest": {
+        "app": {
+          "name": "Speed Test",
+          "category": "Apps"
+        },
+        "metadata": {
+          "author": "MikeS159",
+          "license": "MIT",
+          "url": "https://github.com/MikeS159/tildagon-speedtest",
+          "description": "A simple speed test app, downloads for 5s then displays the speed",
+          "version": "0.1.2"
+        }
+      }
+    },
+    {
+      "code": "11433210",
+      "id": {
+        "service": "github",
+        "owner": "pixelscript",
+        "title": "spinning-cube",
+        "releaseHash": "f10143a965a9398527fd7eb18bb1446d046ab573"
+      },
+      "releaseTime": "2024-06-01T14:19:20Z",
+      "tarballUrl": "https://codeload.github.com/pixelscript/spinning-cube/legacy.tar.gz/f10143a965a9398527fd7eb18bb1446d046ab573",
+      "manifest": {
+        "app": {
+          "name": "Spinning Cube",
+          "category": "Badge"
+        },
+        "metadata": {
+          "author": "pixelscript",
+          "license": "Apache-2.0",
+          "url": "https://www.github.com/pixelscript/spinning-cube",
+          "description": "Literally just a spinning cube. Press buttons to change colours, rotation and trails",
+          "version": "0.0.3"
+        }
+      }
+    },
+    {
+      "code": "34203241",
+      "id": {
+        "service": "github",
+        "owner": "saukothari",
+        "title": "tildagon-spymato",
+        "releaseHash": "7e3207d902553f2b8a7b43de6cdd7c3b8c4a41ee"
+      },
+      "releaseTime": "2024-06-05T09:33:51Z",
+      "tarballUrl": "https://codeload.github.com/saukothari/tildagon-spymato/legacy.tar.gz/7e3207d902553f2b8a7b43de6cdd7c3b8c4a41ee",
+      "manifest": {
+        "app": {
+          "name": "SPYMATO",
+          "category": "Badge"
+        },
+        "metadata": {
+          "author": "saukothari",
+          "license": "LGPL-3.0-only",
+          "url": "https://github.com/saukothari/tildagon-spymato",
+          "description": "Red tomato with animated eyes.",
+          "version": "0.0.1"
+        }
+      }
+    },
+    {
+      "code": "03134443",
+      "id": {
+        "service": "github",
+        "owner": "pixelscript",
+        "title": "starfield",
+        "releaseHash": "4f801c0ebd1e4cf2408f7500a71febf81c986da7"
+      },
+      "releaseTime": "2024-06-01T14:10:54Z",
+      "tarballUrl": "https://codeload.github.com/pixelscript/starfield/legacy.tar.gz/4f801c0ebd1e4cf2408f7500a71febf81c986da7",
+      "manifest": {
+        "app": {
+          "name": "Starfield",
+          "category": "Badge"
+        },
+        "metadata": {
+          "author": "pixelscript",
+          "license": "Apache-2.0",
+          "url": "https://www.github.com/pixelscript/starfield",
+          "description": "A simulation of a starfield press right for colours",
+          "version": "0.0.3"
+        }
+      }
+    },
+    {
+      "code": "23234130",
+      "id": {
+        "service": "github",
+        "owner": "rbirkby",
+        "title": "TildagonTetris",
+        "releaseHash": "20ece7b375cb960304d42bbb091afe5d420edc63"
+      },
+      "releaseTime": "2024-05-31T17:24:25Z",
+      "tarballUrl": "https://codeload.github.com/rbirkby/TildagonTetris/legacy.tar.gz/20ece7b375cb960304d42bbb091afe5d420edc63",
+      "manifest": {
+        "app": {
+          "name": "Tetris",
+          "category": "Games"
+        },
+        "metadata": {
+          "author": "rbirkby",
+          "license": "MIT",
+          "url": "https://www.github.com/rbirkby/TildagonTetris",
+          "description": "Play Tetris on your Tildagon! 🟥🟥🟥🟥",
+          "version": "0.0.4"
+        }
+      }
+    },
+    {
+      "code": "31041130",
+      "id": {
+        "service": "github",
+        "owner": "ntflix",
+        "title": "Tildagon-Bitmap-Demo",
+        "releaseHash": "8825cf7537fdc7d9b3aa26074b532c7a42dd89bc"
+      },
+      "releaseTime": "2024-06-02T22:04:26Z",
+      "tarballUrl": "https://codeload.github.com/ntflix/Tildagon-Bitmap-Demo/legacy.tar.gz/8825cf7537fdc7d9b3aa26074b532c7a42dd89bc",
+      "manifest": {
+        "app": {
+          "name": "TildaGonCrazy",
+          "category": "Badge"
+        },
+        "metadata": {
+          "author": "felixweber",
+          "license": "LGPL-3.0-only",
+          "url": "https://github.com/ntflix/Tildagon-Bitmap-Demo",
+          "description": "Party LEDs! Press different buttons to find out.",
+          "version": "0.1"
+        }
+      }
+    },
+    {
+      "code": "02210022",
+      "id": {
+        "service": "github",
+        "owner": "ChrisDick",
+        "title": "tildagone",
+        "releaseHash": "6de87f05ff2d71c48c2c0a3f01c9e04916f8024f"
+      },
+      "releaseTime": "2025-06-10T21:57:05Z",
+      "tarballUrl": "https://codeload.github.com/ChrisDick/tildagone/legacy.tar.gz/6de87f05ff2d71c48c2c0a3f01c9e04916f8024f",
+      "manifest": {
+        "app": {
+          "name": "TildaGone",
+          "category": "Background"
+        },
+        "metadata": {
+          "author": "ChrisDick",
+          "license": "MIT",
+          "url": "https://www.github.com/ChrisDick/tildagone",
+          "description": "Test background app.",
+          "version": "1.0.3"
+        }
+      }
+    },
+    {
+      "code": "23301133",
+      "id": {
+        "service": "github",
+        "owner": "ntflix",
+        "title": "Tildagon-Torch",
+        "releaseHash": "16fbdd804784b17dc321ec72412ab5b272a8b4e1"
+      },
+      "releaseTime": "2024-06-07T11:45:21Z",
+      "tarballUrl": "https://codeload.github.com/ntflix/Tildagon-Torch/legacy.tar.gz/16fbdd804784b17dc321ec72412ab5b272a8b4e1",
+      "manifest": {
+        "app": {
+          "name": "Torch",
+          "category": "Badge"
+        },
+        "metadata": {
+          "author": "felixweber",
+          "license": "LGPL-3.0-only",
+          "url": "https://github.com/ntflix/Tildagon-Torch",
+          "description": "A torch! Press B to turn on and off.",
+          "version": "1.1"
+        }
+      }
+    },
+    {
+      "code": "32233000",
+      "id": {
+        "service": "github",
+        "owner": "jiphex",
+        "title": "tildagon-torch",
+        "releaseHash": "7fcf4ff429209fae7912eac649c3d353dd38bb19"
+      },
+      "releaseTime": "2024-06-01T14:18:07Z",
+      "tarballUrl": "https://codeload.github.com/jiphex/tildagon-torch/legacy.tar.gz/7fcf4ff429209fae7912eac649c3d353dd38bb19",
+      "manifest": {
+        "app": {
+          "name": "Torchj",
+          "category": "Badge"
+        },
+        "metadata": {
+          "author": "jiphex",
+          "license": "MIT",
+          "url": "https://www.github.com/jiphex/tildagon-torch",
+          "description": "A simple torch, lasts 3-4 hours",
+          "version": "0.0.4"
+        }
+      }
+    },
+    {
+      "code": "04033124",
+      "id": {
+        "service": "github",
+        "owner": "RichardoC",
+        "title": "wifi-switcher",
+        "releaseHash": "d662e961f52ccb161837d8a42c6b6901cc27ab38"
+      },
+      "releaseTime": "2024-09-12T21:26:33Z",
+      "tarballUrl": "https://codeload.github.com/RichardoC/wifi-switcher/legacy.tar.gz/d662e961f52ccb161837d8a42c6b6901cc27ab38",
+      "manifest": {
+        "app": {
+          "name": "Wifi Switcher",
+          "category": "Apps"
+        },
+        "metadata": {
+          "author": "RichardoC",
+          "license": "MIT",
+          "url": "https://www.github.com/RichardoC_wifi_switcher",
+          "description": "Switch between multiple Wifi networks",
+          "version": "1.0.1"
+        }
+      }
+    },
+    {
+      "code": "02240114",
+      "id": {
+        "service": "github",
+        "owner": "usedbytes",
+        "title": "tildagon-wormhole",
+        "releaseHash": "42df5eba30f331978ac3eb825a7e6c9b320a3879"
+      },
+      "releaseTime": "2024-06-02T10:55:19Z",
+      "tarballUrl": "https://codeload.github.com/usedbytes/tildagon-wormhole/legacy.tar.gz/42df5eba30f331978ac3eb825a7e6c9b320a3879",
+      "manifest": {
+        "app": {
+          "name": "Wormhole",
+          "category": "Media"
+        },
+        "metadata": {
+          "author": "usedbytes",
+          "license": "LGPL-3.0-only",
+          "url": "https://github.com/usedbytes/tildagon-wormhole",
+          "description": "A wormhole effect which renders too slowly",
+          "version": "0.0.3"
+        }
+      }
+    }
+  ],
+  "count": 78
+}

--- a/packages/tildagon-app/jest.config.js
+++ b/packages/tildagon-app/jest.config.js
@@ -1,0 +1,15 @@
+import { createDefaultPreset } from "ts-jest";
+
+const tsJestTransformCfg = createDefaultPreset({
+  useESM: true,
+}).transform;
+
+/** @type {import("jest").Config} **/
+export default {
+  testEnvironment: "node",
+  transform: {
+    ...tsJestTransformCfg,
+  },
+  extensionsToTreatAsEsm: [".ts"],
+  testPathIgnorePatterns: ["/build/"],
+};

--- a/packages/tildagon-app/package.json
+++ b/packages/tildagon-app/package.json
@@ -1,9 +1,13 @@
 {
   "name": "tildagon-app",
-  "main": "build/index.js",
-  "module": "build/index.js",
-  "types": "./build/index.d.ts",
+  "main": "build/src/index.js",
+  "module": "build/src/index.js",
+  "types": "./build/src/index.d.ts",
   "dependencies": {
+    "@jest/globals": "^30.4.1",
+    "@types/jest": "^30.0.0",
+    "jest": "^30.4.2",
+    "ts-jest": "^29.4.11",
     "zod": "4.4.3"
   },
   "peerDependencies": {
@@ -11,8 +15,12 @@
   },
   "scripts": {
     "build": "tsc",
-    "check-types": "tsc --noEmit"
+    "check-types": "tsc --noEmit",
+    "test": "NODE_OPTIONS=--experimental-vm-modules jest"
   },
   "type": "module",
-  "private": "true"
+  "private": "true",
+  "devDependencies": {
+    "toml": "^4.1.1"
+  }
 }

--- a/packages/tildagon-app/src/TildagonAppManifest.ts
+++ b/packages/tildagon-app/src/TildagonAppManifest.ts
@@ -12,6 +12,57 @@ export const TildagonAppCategory = z.enum([
 
 export type TildagonAppCategory = z.infer<typeof TildagonAppCategory>;
 
+export const HexpansionIdentifier = z.object({
+  name: z.string().optional(),
+  creator: z.string().optional(),
+  url: z.url().optional(),
+  vid: z.string(),
+  pid: z.string(),
+});
+
+export const Capability = z.string();
+
+export const HexpansionDefinition = z.object({
+  identifier: HexpansionIdentifier,
+  capabilities: z.array(Capability),
+});
+
+export const Frontboard2024 = z.object({
+  name: z.literal("2024 Frontboard"),
+  capabilities: z.tuple([]),
+});
+
+export const Frontboard2026 = z.object({
+  name: z.literal("2026 Frontboard"),
+  capabilities: z.tuple([]),
+});
+
+export const TildagonOSMinimumVersion = z.object({
+  type: "TildagonOSMinimumVersion",
+  version: z.string(),
+});
+
+export const ProvidedCapability = z.object({
+  type: "ProvidedCapability",
+  capability: Capability,
+});
+
+export const Frontboard = z.discriminatedUnion("name", [
+  Frontboard2024,
+  Frontboard2026,
+]);
+
+export const FrontboardIdentifier = z.object({
+  name: z.union(Frontboard.options.map((option) => option.shape.name)),
+});
+
+export const TildagonAppCapabilityAssociations = z.array(
+  z.object({
+    required: z.boolean(),
+    feature: z.union([FrontboardIdentifier, HexpansionIdentifier, Capability]),
+  }),
+);
+
 export const TildagonAppManifestSchema = z.object({
   app: z.object({
     name: z.string(),
@@ -26,6 +77,7 @@ export const TildagonAppManifestSchema = z.object({
     url: z.string(),
     description: z.string(),
     version: z.string(),
+    capabilities: TildagonAppCapabilityAssociations.optional(),
   }),
 });
 

--- a/packages/tildagon-app/test/fixtures/all-categories.toml
+++ b/packages/tildagon-app/test/fixtures/all-categories.toml
@@ -1,0 +1,14 @@
+[app]
+name = "All Categories App"
+category = ["Badge", "Music", "Media", "Apps", "Games", "Background", "Pattern"]
+
+[metadata]
+author = "Test Author"
+license = "MIT"
+url = "https://example.com"
+description = "App with all possible categories"
+version = "1.0.0"
+
+[[metadata.capabilities]]
+required = true
+feature = "all-the-things"

--- a/packages/tildagon-app/test/fixtures/all-optional.toml
+++ b/packages/tildagon-app/test/fixtures/all-optional.toml
@@ -1,0 +1,18 @@
+[app]
+name = "All Optional Capabilities"
+category = "Background"
+
+[metadata]
+author = "Test Author"
+license = "MIT"
+url = "https://example.com"
+description = "App where all capabilities are optional"
+version = "1.0.0"
+
+[[metadata.capabilities]]
+required = false
+feature = "display"
+
+[[metadata.capabilities]]
+required = false
+feature = "audio"

--- a/packages/tildagon-app/test/fixtures/all-required.toml
+++ b/packages/tildagon-app/test/fixtures/all-required.toml
@@ -1,0 +1,22 @@
+[app]
+name = "All Required Capabilities"
+category = "Games"
+
+[metadata]
+author = "Test Author"
+license = "MIT"
+url = "https://example.com"
+description = "App where all capabilities are required"
+version = "1.0.0"
+
+[[metadata.capabilities]]
+required = true
+feature = "input"
+
+[[metadata.capabilities]]
+required = true
+feature = "graphics"
+
+[[metadata.capabilities]]
+required = true
+feature = "storage"

--- a/packages/tildagon-app/test/fixtures/empty-capabilities.toml
+++ b/packages/tildagon-app/test/fixtures/empty-capabilities.toml
@@ -1,0 +1,10 @@
+[app]
+name = "Empty Capabilities App"
+category = "Badge"
+
+[metadata]
+author = "Test Author"
+license = "MIT"
+url = "https://example.com"
+description = "App with no capabilities"
+version = "1.0.0"

--- a/packages/tildagon-app/test/fixtures/invalid-capability-feature.toml
+++ b/packages/tildagon-app/test/fixtures/invalid-capability-feature.toml
@@ -1,0 +1,14 @@
+[app]
+name = "Invalid Capability Feature App"
+category = "Badge"
+
+[metadata]
+author = "Test Author"
+license = "MIT"
+url = "https://example.com"
+description = "App with invalid capability feature type"
+version = "1.0.0"
+
+[[metadata.capabilities]]
+required = true
+feature = 123

--- a/packages/tildagon-app/test/fixtures/invalid-category.toml
+++ b/packages/tildagon-app/test/fixtures/invalid-category.toml
@@ -1,0 +1,10 @@
+[app]
+name = "Invalid Category App"
+category = "InvalidCat"
+
+[metadata]
+author = "Test Author"
+license = "MIT"
+url = "https://example.com"
+description = "App with invalid category"
+version = "1.0.0"

--- a/packages/tildagon-app/test/fixtures/many-capabilities.toml
+++ b/packages/tildagon-app/test/fixtures/many-capabilities.toml
@@ -1,0 +1,34 @@
+[app]
+name = "Many Capabilities"
+category = "Music"
+
+[metadata]
+author = "Test Author"
+license = "MIT"
+url = "https://example.com"
+description = "App with many capabilities"
+version = "1.0.0"
+
+[[metadata.capabilities]]
+required = true
+feature = "audio"
+
+[[metadata.capabilities]]
+required = true
+feature = "midi"
+
+[[metadata.capabilities]]
+required = true
+feature = "sequencer"
+
+[[metadata.capabilities]]
+required = false
+feature = "sampler"
+
+[[metadata.capabilities]]
+required = false
+feature = "effects"
+
+[[metadata.capabilities]]
+required = false
+feature = "mixer"

--- a/packages/tildagon-app/test/fixtures/minimal.toml
+++ b/packages/tildagon-app/test/fixtures/minimal.toml
@@ -1,0 +1,10 @@
+[app]
+name = "Minimal App"
+category = "Badge"
+
+[metadata]
+author = "Test Author"
+license = "MIT"
+url = "https://example.com"
+description = "Minimal app with no capabilities field"
+version = "1.0.0"

--- a/packages/tildagon-app/test/fixtures/missing-app-name.toml
+++ b/packages/tildagon-app/test/fixtures/missing-app-name.toml
@@ -1,0 +1,9 @@
+[app]
+category = "Badge"
+
+[metadata]
+author = "Test Author"
+license = "MIT"
+url = "https://example.com"
+description = "App with missing name"
+version = "1.0.0"

--- a/packages/tildagon-app/test/fixtures/missing-capability-fields.toml
+++ b/packages/tildagon-app/test/fixtures/missing-capability-fields.toml
@@ -1,0 +1,12 @@
+[app]
+name = "Missing Capability Fields App"
+category = "Badge"
+
+[metadata]
+author = "Test Author"
+license = "MIT"
+url = "https://example.com"
+description = "App with capability missing required and feature fields"
+version = "1.0.0"
+
+[[metadata.capabilities]]

--- a/packages/tildagon-app/test/fixtures/missing-metadata-author.toml
+++ b/packages/tildagon-app/test/fixtures/missing-metadata-author.toml
@@ -1,0 +1,9 @@
+[app]
+name = "Missing Author App"
+category = "Badge"
+
+[metadata]
+license = "MIT"
+url = "https://example.com"
+description = "App with missing author"
+version = "1.0.0"

--- a/packages/tildagon-app/test/fixtures/multiple-mixed.toml
+++ b/packages/tildagon-app/test/fixtures/multiple-mixed.toml
@@ -1,0 +1,26 @@
+[app]
+name = "Multiple Mixed Capabilities"
+category = ["Apps", "Games"]
+
+[metadata]
+author = "Test Author"
+license = "MIT"
+url = "https://example.com"
+description = "App with multiple capabilities, some required"
+version = "2.0.0"
+
+[[metadata.capabilities]]
+required = true
+feature = "gpio"
+
+[[metadata.capabilities]]
+required = true
+feature = "i2c"
+
+[[metadata.capabilities]]
+required = false
+feature = "spi"
+
+[[metadata.capabilities]]
+required = false
+feature = "uart"

--- a/packages/tildagon-app/test/fixtures/non-url-string.toml
+++ b/packages/tildagon-app/test/fixtures/non-url-string.toml
@@ -1,0 +1,10 @@
+[app]
+name = "Invalid URL App"
+category = "Badge"
+
+[metadata]
+author = "Test Author"
+license = "MIT"
+url = "not-a-valid-url"
+description = "App with invalid URL"
+version = "1.0.0"

--- a/packages/tildagon-app/test/fixtures/simple-capability.toml
+++ b/packages/tildagon-app/test/fixtures/simple-capability.toml
@@ -1,0 +1,18 @@
+[app]
+name = "Simple Capability App"
+category = ["Apps", "Games"]
+
+[metadata]
+author = "Test Author"
+license = "MIT"
+url = "https://example.com"
+description = "App with a simple string capability"
+version = "1.0.0"
+
+[[metadata.capabilities]]
+required = true
+feature = "gpio"
+
+[[metadata.capabilities]]
+required = false
+feature = "i2c"

--- a/packages/tildagon-app/test/fixtures/single-category.toml
+++ b/packages/tildagon-app/test/fixtures/single-category.toml
@@ -1,0 +1,14 @@
+[app]
+name = "Single Category App"
+category = "Media"
+
+[metadata]
+author = "Test Author"
+license = "MIT"
+url = "https://example.com"
+description = "App with single category and capabilities"
+version = "1.0.0"
+
+[[metadata.capabilities]]
+required = true
+feature = "video"

--- a/packages/tildagon-app/test/fixtures/single-optional.toml
+++ b/packages/tildagon-app/test/fixtures/single-optional.toml
@@ -1,0 +1,14 @@
+[app]
+name = "Single Optional Capability"
+category = "Pattern"
+
+[metadata]
+author = "Test Author"
+license = "MIT"
+url = "https://example.com"
+description = "App with one optional capability"
+version = "1.0.0"
+
+[[metadata.capabilities]]
+required = false
+feature = "animation"

--- a/packages/tildagon-app/test/fixtures/single-required.toml
+++ b/packages/tildagon-app/test/fixtures/single-required.toml
@@ -1,0 +1,14 @@
+[app]
+name = "Single Required Capability"
+category = "Apps"
+
+[metadata]
+author = "Test Author"
+license = "MIT"
+url = "https://example.com"
+description = "App with one required capability"
+version = "1.0.0"
+
+[[metadata.capabilities]]
+required = true
+feature = "gpio"

--- a/packages/tildagon-app/test/manifest.test.ts
+++ b/packages/tildagon-app/test/manifest.test.ts
@@ -1,0 +1,32 @@
+import { readdirSync } from "node:fs";
+import { readFile } from "node:fs/promises";
+import { TildagonAppManifestSchema } from "../src/TildagonAppManifest";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { parse } from "toml";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+function getManifestFixtures() {
+  const fixturesDir = join(__dirname, "fixtures");
+  const files = readdirSync(fixturesDir);
+  return files.filter((f) => f.endsWith(".toml")).map((f) => ({ filename: f }));
+}
+
+test.each(getManifestFixtures())(
+  "manifest file $filename",
+  async ({ filename }) => {
+    const filepath = join(__dirname, "fixtures", filename);
+    const file = await readFile(filepath, "utf-8");
+    const manifest = parse(file);
+
+    const isInvalidFixture =
+      filename.startsWith("invalid-") || filename.startsWith("missing-");
+
+    if (isInvalidFixture) {
+      expect(() => TildagonAppManifestSchema.parse(manifest)).toThrow();
+    } else {
+      TildagonAppManifestSchema.parse(manifest);
+    }
+  },
+);

--- a/packages/tildagon-app/tsconfig.json
+++ b/packages/tildagon-app/tsconfig.json
@@ -25,9 +25,9 @@
     // "moduleDetection": "auto",                        /* Control what method is used to detect module-format JS files. */
 
     /* Modules */
-    "module": "Node16" /* Specify what module code is generated. */,
+    "module": "es2022" /* Specify what module code is generated. */,
     // "rootDir": "./",                                  /* Specify the root folder within your source files. */
-    "moduleResolution": "node16",                     /* Specify how TypeScript looks up a file from a given module specifier. */
+    "moduleResolution": "bundler",                     /* Specify how TypeScript looks up a file from a given module specifier. */
     // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
     // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
@@ -74,7 +74,7 @@
     // "preserveValueImports": true,                     /* Preserve unused imported values in the JavaScript output that would otherwise be removed. */
 
     /* Interop Constraints */
-    // "isolatedModules": true,                          /* Ensure that each file can be safely transpiled without relying on other imports. */
+    "isolatedModules": true,                          /* Ensure that each file can be safely transpiled without relying on other imports. */
     // "verbatimModuleSyntax": true,                     /* Do not transform or elide any imports or exports not marked as type-only, ensuring they are written in the output file's format based on the 'module' setting. */
     // "allowSyntheticDefaultImports": true,             /* Allow 'import x from y' when a module doesn't have a default export. */
     "esModuleInterop": true /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */,


### PR DESCRIPTION
This PR introduces Zod types that specify the way app authors will provide their hardware requirements in their tildagon.toml files.

An app with that requires the 2026 frontboard, supports GPS, and supports the 0xAAA,0xBBB hexpansion would add this snippet to their tildagon.toml.


```toml
# This specifies a hard requirement of the 2026 frontboard.
[[hardware]]
feature = "2026 Frontboard"
required = true

# This is a second hardware specifier, in this case optional (so "supports", not "requires")
# Apps can have as many hardware specifiers as they like
[[hardware]]
# "GPS" is an arbitrary string, so that app authors and hexpansion creators don't need
# to wait for our central approval for hardware capability naming
feature = "GPS"
required = false

# This specifies a requirement on a particular hexpansion
[[hardware]]
required = false
  # In this "hardware" object, the "feature" property is an object, not a
  # frontboard identifier or arbitrary string capability
  [hardware.feature]
  vid = 0xAAA
  pid = 0xBBB

```

While the above is the "toml" way to write it, using a feature called "arrays of tables", this syntax is also valid and more familiar to me:

```toml
hardware = [
    { feature = "Frontboard 2026", required = true },
    { feature = "GPS" },
    { feature = { vid = 0xAAA, pid = 0xBBB } }
]
```

It introduces the term "Hardware Feature", which can be:

- Hexpansions specified by vid/pid
- Frontboards
- Capabilities offered by hexpansions or frontboards

And the term "Hardware Association" (could be called "Hardware Specifier"), which is the name of the object in tildagon.toml that specifies which Hardware Feature is either _required_ or _supported_ by the app. Apps can specify multiple Hardware Associations.

This allows for:

- Specifying that an app *requires* a specific hardware feature
- Specifying that an app *supports* a specific hardware feature
- Specifying requirements and support for multiple kinds of hardware at the same time
- Hackers to define ad-hoc hardware capabilities rather than relying on a predefined list of requirements.

And does not allow for

- Specifying that an app requires a specific hardware feature *not* to be present
- Specifying that an app depends on another app (this seems like something we should maybe do)

## Glossary

<dl>
<dt>Hardware Feature<dt>
<dd>A piece of physical hardware (either frontboard or hexpansion) *or* a Capability (described below</dd>
<dt>Hardware Association<dt>
<dd>The table in the tildagon.toml of an app that specifies which Hardware Features are either _required_ or _supported_</dt>
<dt>Capability</dt>
<dd>An arbitrary string that identifies some kind of hardware capability - e.g. "GPS"</dd>
</dl>

## Capability

This proposal includes the concept of a "Capability" - here meaning "an arbitrary string that identifies some capability that hardware (and in the future possibly apps) can specify that they provide. An example capability would be "GPS". If an app says that it supports "GPS", it's saying that it will use an interface (agreed on out-of-band) to access GPS data. This proposal specifies capabilities as arbitrary strings so that app authors and hexpansion creators have the ability to define Capabilities independently of badge team. We rely on app authors and hexpansion creators (as we would regardless of this proposal) to correctly implement the integration, and to strive to not introduce ambiguity into the interface. We should therefore encourage as simple interfaces as possible. Treating capability identifiers as arbitrary strings allows maximum flexibility, in that it does not preclude hexpansion creators, app authors, and badge team from defining capabilities more stringently. We could create a Capability specification registry (and so could anyone else) where the string identifier of the Capability is a URL that resolves to the specification of the capability. For example:

```toml
[[hardware]]
required = true
feature = "https://www.bodgeham-cryptozoolocial-society-gov.uk/capabilities/badger-detection-v1"
```

Then the document at that URL would specify the badger detection feature and document how apps can use that capability.


## I would like feedback on:

- things that we need to be able to do that this proposal doesn't allow for
- places where this proposal is flexible in ways we don't want to be flexible
- names of things
- I don't particularly like how toml does tables inside arrays of tables, so if someone knows how we could avoid that, I would be interested.

## Things not (yet) in scope

- How the badge will report capabilities
  - We'll need a mechanism for the badge to report which hexpansions and frontboard are attached
  - And for hexpansions to report which capabilities they implement
- How capabilities will be specified.