### PR TITLE
Feat/build in ci

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -1,0 +1,51 @@
+name: build app-store container
+
+on:
+  pull_request:
+  workflow_dispatch:
+  push:
+    tags:
+      - "v*"
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: emfcamp/app-store
+  APP_STORE_VERSION: test-build  # we would get this from $release or whatever
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+      
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push Docker image
+        id: push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          # push: ${{ github.event_name != 'pull_request' }}
+          push: true 
+          platforms: linux/amd64  #,linux/arm64  # I don't think we need multi-arch builds, and the ARM build is sloooooooow
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.APP_STORE_VERSION }}
+    

--- a/mise.toml
+++ b/mise.toml
@@ -6,7 +6,7 @@ node = "latest"
 
 [env]
 GITHUB_TOKEN = { value = "${GITHUB_TOKEN:-}", redact = true }
-APP_STORE_MOCK = true
+APP_STORE_MOCK = false
 PORT = "3000"
 
 [tasks.build-library]


### PR DESCRIPTION
# Build the `app-store` Docker image in CI!

I copied and sweetened the [workflow from the badge-software repo](https://github.com/emfcamp/badge-2024-software/blob/main/.github/workflows/build-container.yml)

A few things before we think about merging this:

* The tag is hard-coded as `test-build` here, we'd want to get this from the `release` name
* For testing, I've set `push` to `true`, we want to push only on a proper `release`
* I don't think we need multi-arch builds here, and building for ARM is slooooooooow so I've disabled that 

Having said all that, [it works](https://github.com/emfcamp/badge-2024-app-store/actions/runs/27509994006) and produces [an image](https://github.com/emfcamp/badge-2024-app-store/pkgs/container/app-store)!

## Pull and test it

```
docker logout
echo ${GITHUB_TOKEN} | docker login ghcr.io --username $(git config --get user.name) --password-stdin
docker run --interactive --tty --rm --publish 3000:3000 --env GITHUB_TOKEN=${GITHUB_TOKEN} ghcr.io/emfcamp/app-store:test-build
```

Where `${GITHUB_TOKEN}` has at least `read:packages` powers