### PR TITLE
Enable pagination for Codeberg queries.

### DIFF
--- a/packages/tildagon-app-directory-api/src/registries/sources/codeberg.ts
+++ b/packages/tildagon-app-directory-api/src/registries/sources/codeberg.ts
@@ -16,15 +16,28 @@ import TOML from "@ltd/j-toml";
 const API_BASE_URL = "https://codeberg.org";
 const api = forgejoApi(API_BASE_URL);
 
+type Repo = NonNullable<
+  Awaited<ReturnType<typeof api.repos.repoSearch>>["data"]["data"]
+>[number];
+
 async function getTildagonApps(): RegistrySourceListResult<MetadataFromListing> {
-  const results = await api.repos.repoSearch({
-    q: "tildagon-app",
-    topic: true,
-    archived: false,
-  });
+  const repos: Repo[] = [];
+  let page = 1;
+  while (true) {
+    const results = await api.repos.repoSearch({
+      q: "tildagon-app",
+      topic: true,
+      archived: false,
+      page,
+    });
+    const pageData = results.data?.data ?? [];
+    if (pageData.length === 0) break;
+    repos.push(...pageData);
+    page++;
+  }
 
   return await Promise.all(
-    results.data?.data?.map(async (repo) => {
+    repos.map(async (repo) => {
       try {
         const latestRelease = await api.repos.repoGetLatestRelease(
           repo.owner?.login!,
@@ -55,7 +68,7 @@ async function getTildagonApps(): RegistrySourceListResult<MetadataFromListing> 
           },
         };
       }
-    }) ?? [],
+    }),
   );
 }
 


### PR DESCRIPTION
The Forgejo search API defaults to fetching up to 30 results per query - that can be increased, but either way, it also supports pagination. The current Codeberg query module does not handle pagination. At the time of creating this PR there are 34 apps that match the `tildagon-app` topic, so four of them are never picked up or updated.

Proposing this small change for review - the principle is that we loop through requests until we reach an empty set, so in principle we don't just hit a new wall by increasing the result set to the max (100), we're safe for future pages of results.

Tested locally as working, but my TypeScript is very slim. 🤞🏻 