### PR TITLE
fix: restore GitHub Pages static deployment after SSR dockerization

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,10 +27,11 @@ jobs:
         run: mise run check
       - name: Run tests
         run: npm run test
-      - name: Run directory
+      - name: Build website (static)
         run: mise run build-website
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          APP_STORE_STATIC: true
       - name: Upload site artifact
         if: github.ref == 'refs/heads/main'
         uses: actions/upload-pages-artifact@v5

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -43,4 +43,14 @@ export default tseslint.config(
       "@typescript-eslint/triple-slash-reference": "off",
     },
   },
+
+  // Allow Node.js globals in config files
+  {
+    files: ["**/astro.config.mjs", "**/*.config.{js,mjs,ts}"],
+    languageOptions: {
+      globals: {
+        process: "readonly",
+      },
+    },
+  },
 );

--- a/packages/tildagon-app-directory-site/astro.config.mjs
+++ b/packages/tildagon-app-directory-site/astro.config.mjs
@@ -2,12 +2,19 @@ import { defineConfig } from "astro/config";
 import icon from "astro-icon";
 import node from "@astrojs/node";
 
+// Use static mode for GitHub Pages, server mode for Docker SSR
+const isStatic = process.env.APP_STORE_STATIC === "true";
+
 // https://astro.build/config
 export default defineConfig({
-  adapter: node({
-    mode: "standalone",
-  }),
-  output: "server",
+  ...(isStatic
+    ? { output: "static" }
+    : {
+        adapter: node({
+          mode: "standalone",
+        }),
+        output: "server",
+      }),
   site: "https://apps.badge.emfcamp.org",
   //base: process.env.CI ? "/badge-2024-app-store" : undefined,
   integrations: [


### PR DESCRIPTION
PR #125 introduced SSR mode for Docker, but broke GitHub Pages by producing a server-side dist/ structure (client/ + server/) instead of flat static HTML. GitHub Pages can only serve static files.

Make the Astro output mode conditional on APP_STORE_STATIC env var:
- APP_STORE_STATIC=true: output "static" for GitHub Pages
- default: output "server" with @astrojs/node for Docker SSR

Update deploy.yml to set APP_STORE_STATIC=true, so the GitHub Pages workflow builds a proper static site artifact.