### PR TITLE
Make glyphs render in body text.

### DIFF
--- a/packages/tildagon-app-directory-site/src/styles/global.css
+++ b/packages/tildagon-app-directory-site/src/styles/global.css
@@ -26,3 +26,7 @@ a {
 .badge-colored {
   background-color: var(--badge-bg, #777);
 }
+
+p {
+  font-family: Raleway, "Helvetica Neue", Helvetica, Arial, sans-serif;
+}


### PR DESCRIPTION
Tiny tweak so that EMF Camp Font / Raleway works in body text as well as in app titles.

For the ducks.