### PR TITLE
feat: parallelise app metadata fetch, cache npm deps in actions workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,7 +22,18 @@ jobs:
         run: cp mise.ci.toml mise.local.toml
       - name: Setup mise
         uses: jdx/mise-action@v4
+      - name: Cache node modules
+        id: npm-cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            node_modules
+            packages/*/node_modules
+          key: ${{ runner.os }}-npm-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-npm-
       - name: Install dependencies
+        if: steps.npm-cache.outputs.cache-hit != 'true'
         run: npm install
       - name: Run checks
         if: github.event_name == 'pull_request'

--- a/packages/tildagon-app-directory-api/index.ts
+++ b/packages/tildagon-app-directory-api/index.ts
@@ -21,7 +21,13 @@ import {
   type IncomingMessage,
   type ServerResponse,
 } from "node:http";
-import { writeFileSync, existsSync, readFileSync, statSync, createReadStream } from "node:fs";
+import {
+  writeFileSync,
+  existsSync,
+  readFileSync,
+  statSync,
+  createReadStream,
+} from "node:fs";
 import { extname, join, normalize, resolve } from "node:path";
 import { Readable } from "node:stream";
 import { pipeline } from "node:stream/promises";
@@ -109,7 +115,12 @@ api.options("*", (c) => {
 
 // Response cache middleware — skip for health/status/metrics and during refresh
 api.use("*", async (c, next) => {
-  if (c.req.path === "/v1/health" || c.req.path === "/v1/status" || c.req.path === "/metrics" || c.req.path.startsWith("/v1/tarballs")) {
+  if (
+    c.req.path === "/v1/health" ||
+    c.req.path === "/v1/status" ||
+    c.req.path === "/metrics" ||
+    c.req.path.startsWith("/v1/tarballs")
+  ) {
     return next();
   }
 

--- a/packages/tildagon-app-directory-api/src/registries/CachedRegistryManager.ts
+++ b/packages/tildagon-app-directory-api/src/registries/CachedRegistryManager.ts
@@ -52,16 +52,45 @@ const DEFAULT_SOURCES: RegistrySource<any>[] =
     : [GitHubRegistry, CodebergRegistry];
 
 /**
+ * Runs `fn` over `items` with at most `concurrency` calls in flight at once,
+ * preserving the input order in the returned array.
+ */
+async function mapWithConcurrency<T, R>(
+  items: T[],
+  concurrency: number,
+  fn: (item: T) => Promise<R>,
+): Promise<R[]> {
+  const results: R[] = new Array(items.length);
+  let cursor = 0;
+
+  async function worker(): Promise<void> {
+    while (cursor < items.length) {
+      const index = cursor++;
+      results[index] = await fn(items[index]!);
+    }
+  }
+
+  const workerCount = Math.max(1, Math.min(concurrency, items.length));
+  await Promise.all(Array.from({ length: workerCount }, () => worker()));
+  return results;
+}
+
+/**
  * Creates a CachedRegistryManager that orchestrates listing and fetching
  * apps from the given registry sources. Sources are injected so the
  * manager can be tested with mock registries.
  */
 export function createCachedRegistryManager(
   sources: RegistrySource<any>[],
-  options?: { clock?: () => number; refreshIntervalMs?: number },
+  options?: {
+    clock?: () => number;
+    refreshIntervalMs?: number;
+    getConcurrency?: number;
+  },
 ) {
   const now = options?.clock ?? (() => Date.now());
   const refreshIntervalMs = options?.refreshIntervalMs ?? 600_000;
+  const getConcurrency = options?.getConcurrency ?? 10;
 
   // ── Disk cache ──────────────────────────────────────────
 
@@ -363,7 +392,20 @@ export function createCachedRegistryManager(
           }
         }
 
-        // 3. Process each listing result
+        // 3. Gather the apps that need a `get()` call across all sources, then
+        // fetch them in parallel (bounded by getConcurrency) instead of one
+        // at a time. Failures from the listing stage are recorded immediately
+        // since they require no further network calls.
+        const fetchJobs: {
+          code: string;
+          sourceIndex: number;
+          source: RegistrySource<any>;
+          listingResult: { id: TildagonAppReleaseIdentifier } & Record<
+            string,
+            any
+          >;
+        }[] = [];
+
         for (const { source, sourceIndex, results, succeeded } of listings) {
           if (!succeeded) continue;
           const seen = seenBySource.get(sourceIndex)!;
@@ -381,7 +423,12 @@ export function createCachedRegistryManager(
               result.value.id,
             );
             seen.add(code);
-            await safelyGetApp(code, sourceIndex, source, result.value);
+            fetchJobs.push({
+              code,
+              sourceIndex,
+              source,
+              listingResult: result.value,
+            });
           }
 
           refreshLastSuccessByService.set(
@@ -389,6 +436,10 @@ export function createCachedRegistryManager(
             ts / 1000,
           );
         }
+
+        await mapWithConcurrency(fetchJobs, getConcurrency, (job) =>
+          safelyGetApp(job.code, job.sourceIndex, job.source, job.listingResult),
+        );
 
         // 4. Delete apps whose source succeeded but no longer lists them
         for (const [code, entry] of AppCache) {

--- a/packages/tildagon-app-directory-api/src/registries/CachedRegistryManager.ts
+++ b/packages/tildagon-app-directory-api/src/registries/CachedRegistryManager.ts
@@ -11,7 +11,13 @@ import {
 import { disallowedApps } from "./disallowlist";
 import { CodebergRegistry } from "./sources/codeberg";
 import equal from "fast-deep-equal/es6";
-import { writeFileSync, readFileSync, existsSync, mkdirSync, unlinkSync } from "node:fs";
+import {
+  writeFileSync,
+  readFileSync,
+  existsSync,
+  mkdirSync,
+  unlinkSync,
+} from "node:fs";
 import { join } from "node:path";
 import { createWriteStream } from "node:fs";
 import { pipeline } from "node:stream/promises";
@@ -129,9 +135,7 @@ export function createCachedRegistryManager(
   function loadFromDisk(): boolean {
     try {
       if (!existsSync(CACHE_FILE)) return false;
-      const raw: DiskCacheData = JSON.parse(
-        readFileSync(CACHE_FILE, "utf-8"),
-      );
+      const raw: DiskCacheData = JSON.parse(readFileSync(CACHE_FILE, "utf-8"));
 
       for (const { sourceIndex, app } of raw.apps) {
         try {
@@ -438,7 +442,12 @@ export function createCachedRegistryManager(
         }
 
         await mapWithConcurrency(fetchJobs, getConcurrency, (job) =>
-          safelyGetApp(job.code, job.sourceIndex, job.source, job.listingResult),
+          safelyGetApp(
+            job.code,
+            job.sourceIndex,
+            job.source,
+            job.listingResult,
+          ),
         );
 
         // 4. Delete apps whose source succeeded but no longer lists them

--- a/packages/tildagon-app-directory-api/src/registries/sources/codeberg.ts
+++ b/packages/tildagon-app-directory-api/src/registries/sources/codeberg.ts
@@ -143,7 +143,10 @@ async function getTildagonApp(
     const manifest = TildagonAppManifestSchema.safeParse(parsed);
 
     if (manifest.error) {
-      return { type: "failure", failure: { id, reason: manifest.error.message } };
+      return {
+        type: "failure",
+        failure: { id, reason: manifest.error.message },
+      };
     }
 
     const appRelease: TildagonAppRelease = {


### PR DESCRIPTION
`CachedRegistryManager.refreshAllSources()` fetched each app's manifest `tildagon.toml` sequentially, one HTTP request at a time, even though GitHub and Codeberg listings were fetched in parallel. This caused hundreds of HTTP requests in serial per update. Flattens the fetch across all sources and runs them with a bounded concurrency pool instead.

Also cache node_modules in the deploy workflow.

Seems to cut down the update speed quite a bit.