### PR TITLE
Add a test for apps specifying a minimum Tildagon OS version

### DIFF
--- a/packages/tildagon-app/src/TildagonAppManifest.ts
+++ b/packages/tildagon-app/src/TildagonAppManifest.ts
@@ -39,7 +39,7 @@ export const Frontboard2026 = z.object({
 });
 
 export const TildagonOSMinimumVersion = z.object({
-  type: "TildagonOSMinimumVersion",
+  type: z.literal("TildagonOSMinimumVersion"),
   version: z.string(),
 });
 
@@ -60,7 +60,7 @@ export const FrontboardIdentifier = z.object({
 export const TildagonAppCapabilityAssociations = z.array(
   z.object({
     required: z.boolean(),
-    feature: z.union([FrontboardIdentifier, HexpansionIdentifier, Capability]),
+    feature: z.union([FrontboardIdentifier, HexpansionIdentifier, Capability, TildagonOSMinimumVersion]),
   }),
 );
 

--- a/packages/tildagon-app/test/fixtures/tildagon-os.toml
+++ b/packages/tildagon-app/test/fixtures/tildagon-os.toml
@@ -1,0 +1,14 @@
+[app]
+name = "Min Tildagon OS App"
+category = ["Apps", "Games"]
+
+[metadata]
+author = "Test Author"
+license = "MIT"
+url = "https://example.com"
+description = "App that requires a minimum Tildagon OS version"
+version = "1.0.0"
+
+[[metadata.capabilities]]
+required = true
+feature = { type = "TildagonOSMinimumVersion", version = "2.0.0" }


### PR DESCRIPTION
Hi,

I couldn't figure out how to use the TildagonOSMinimumVersion capability and there seems to be no test fixture illustrating it.

I wanted to add a test case, should it be something like this? (I had to tweak the schema to get it to work, so I may be incorrect here!)