### PR TITLE
Show Tildagon OS minimum version requirement on app pages

### DIFF
--- a/packages/tildagon-app-directory-api/index.ts
+++ b/packages/tildagon-app-directory-api/index.ts
@@ -263,7 +263,10 @@ api.get("/v1/apps/:code", async (c) => {
 api.get("/v1/apps", async (c) => {
   const filters = parseAppFilters(c);
   const apps = await CachedRegistryManager.listApps(filters);
-  return c.json({ items: apps.map((a) => proxyTarballUrl(a, getBaseUrl(c))), count: apps.length });
+  return c.json({
+    items: apps.map((a) => proxyTarballUrl(a, getBaseUrl(c))),
+    count: apps.length,
+  });
 });
 
 // GET /v1/failures

--- a/packages/tildagon-app-directory-site/src/pages/apps/[code].astro
+++ b/packages/tildagon-app-directory-site/src/pages/apps/[code].astro
@@ -36,6 +36,9 @@ function capabilityLabel(feature: any): { label: string; filter: string } | null
     const { vid, pid, name } = feature.identifier;
     return { label: name || `VID:${vid} PID:${pid}`, filter: `vid=${encodeURIComponent(vid)}&pid=${encodeURIComponent(pid)}` };
   }
+  if (feature.type === "TildagonOSMinimumVersion") {
+    return { label: `Tildagon OS >= ${feature.version}`, filter: '' };
+  }
   if (typeof feature.type === "string" && feature.type.includes("Frontboard")) {
     return { label: feature.type, filter: `frontboard=${encodeURIComponent(feature.type)}` };
   }

--- a/packages/tildagon-app/src/TildagonAppManifest.ts
+++ b/packages/tildagon-app/src/TildagonAppManifest.ts
@@ -60,7 +60,12 @@ export const FrontboardIdentifier = z.object({
 export const TildagonAppCapabilityAssociations = z.array(
   z.object({
     required: z.boolean(),
-    feature: z.union([FrontboardIdentifier, HexpansionIdentifier, Capability, TildagonOSMinimumVersion]),
+    feature: z.union([
+      FrontboardIdentifier,
+      HexpansionIdentifier,
+      Capability,
+      TildagonOSMinimumVersion,
+    ]),
   }),
 );
 


### PR DESCRIPTION
This change properly allows the Tildagon OS version requirement to be shown on app pages instead of "Unknown"

Before this change:

<img width="281" height="235" alt="image" src="https://github.com/user-attachments/assets/30733160-cbff-4999-8deb-e9bcc06c0653" />

After this change: 

<img width="281" height="235" alt="image" src="https://github.com/user-attachments/assets/a4adf8f0-ba71-4170-be8e-2e70cf5005d8" />
